### PR TITLE
Add 'prepare' hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+lib

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "thompson",
   "private": true,
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "test": "ts-node src/test.ts"
+    "build": "tsc -p .",
+    "test": "ts-node src/test.ts",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "rerejs": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "thompson",
+  "version": "0.1.0",
   "private": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "module": "commonjs",
     "downlevelIteration": true,
     "strict": true,
-    "moduleResolution": "node"
-  }
+    "moduleResolution": "node",
+    "declaration": true,
+    "rootDir": "./src",
+    "outDir": "./lib"
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
`npm install github:n4o847/seccamp-redos` のようにしてインストールしたときに、ビルド済みの JavaScript ファイルなどが追加されるように修正しました。