### PR TITLE
二重辺対応, 直積グラフを更に強連結成分分解してEDAを検知

### DIFF
--- a/src/eda.ts
+++ b/src/eda.ts
@@ -19,7 +19,7 @@ function isEDA(dp: DirectProductNFA): boolean {
   return sccs.some((scc) => {
     // Setがもとの二重辺の配列よりサイズが小さくなれば二重辺が存在
     for (const source of scc.stateList) {
-      const loopBackStr = scc.transitions
+      const loopBackStringArray = scc.transitions
         .get(source)!
         .filter((tr) => {
           return source === tr.destination;
@@ -27,9 +27,9 @@ function isEDA(dp: DirectProductNFA): boolean {
         .map((tr) => {
           return tr.charSet.toString();
         });
-      const loopBackSet = new Set(Array.from(loopBackStr));
+      const loopBackSet = new Set(loopBackStringArray);
 
-      if (loopBackSet.size < loopBackStr.length) {
+      if (loopBackSet.size < loopBackStringArray.length) {
         return true;
       }
     }

--- a/src/eda.ts
+++ b/src/eda.ts
@@ -27,9 +27,9 @@ function isEDA(dp: DirectProductNFA): boolean {
         .map((tr) => {
           return tr.charSet.toString();
         });
-      const loopBackSet = new Set(loopBackStringArray);
+      const loopBackStringSet = new Set(loopBackStringArray);
 
-      if (loopBackSet.size < loopBackStringArray.length) {
+      if (loopBackStringSet.size < loopBackStringArray.length) {
         return true;
       }
     }

--- a/src/scc.ts
+++ b/src/scc.ts
@@ -1,12 +1,12 @@
 import {
-  NonEpsilonNFA,
   NonNullableTransition,
+  SCCPossibleAutomaton,
   State,
   StronglyConnectedComponentNFA,
 } from './types';
 
 export function buildStronglyConnectedComponents(
-  nfa: NonEpsilonNFA,
+  nfa: SCCPossibleAutomaton,
 ): StronglyConnectedComponentNFA[] {
   return new StronglyConnectedComponents(nfa).build();
 }
@@ -18,7 +18,7 @@ class StronglyConnectedComponents {
   private comp: Map<State, number> = new Map();
   private sccList: StronglyConnectedComponentNFA[] = [];
 
-  constructor(private nfa: NonEpsilonNFA) {}
+  constructor(private nfa: SCCPossibleAutomaton) {}
 
   build(): StronglyConnectedComponentNFA[] {
     this.nfa.stateList.forEach((state) => {

--- a/src/test.ts
+++ b/src/test.ts
@@ -17,6 +17,7 @@ function main() {
     [String.raw`a*?`],
     [String.raw`(?:)`],
     [String.raw`(?:a|bc)`],
+    [String.raw`(a|b)*`],
     [String.raw`(a*)*`],
     [String.raw`(a+)+`],
     [String.raw`(a?)?`],

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type Automaton =
   | StronglyConnectedComponentNFA
   | DirectProductNFA;
 
+export type SCCPossibleAutomaton = NonEpsilonNFA | DirectProductNFA;
+
 export type EpsilonNFA = {
   type: 'EpsilonNFA';
   alphabet: number[];


### PR DESCRIPTION
# WHAT

-  二重辺対応 
`(a*)*`などを検知
-  直積グラフを更に強連結成分分解して, その部分グラフが(n, n), (m, k) (m !== k)となる点が存在するか検知するように
`(a|b)*`などを誤検知しないように
-  SCCPossibleAutomatonという強連結成分分解が可能な型を定義