### PR TITLE
#5 IDA検出実装

### DIFF
--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -89,7 +89,7 @@ class DirectProducer {
 
   getState(leftState: State, rightState: State): State | null {
     for (const [ns, os] of this.newStateToOldStateSet) {
-      if (os[0] === leftState && os[1] == rightState) {
+      if (os[0] === leftState && os[1] === rightState) {
         return ns;
       }
     }

--- a/src/ida.ts
+++ b/src/ida.ts
@@ -5,7 +5,7 @@ export function showMessageIDA(tdps: TripleDirectProductNFA[]): Message {
   if (tdps.some((tdp) => isIDA(tdp))) {
     return { status: 'Vulnerable', message: 'Detected IDA.' };
   } else {
-    return { status: 'Safe', message: 'Don\'t have IDA.' };
+    return { status: 'Safe', message: "Don't have IDA." };
   }
 }
 
@@ -16,9 +16,9 @@ function isIDA(tdp: TripleDirectProductNFA): boolean {
 
     for (const [q, ts] of tdp.extraTransitions) {
       for (const t of ts) {
-        return scc.transitions.get(t.destination)?.some(
-          (scc_dest) => scc_dest.destination === q
-        );
+        return scc.transitions
+          .get(t.destination)
+          ?.some((scc_dest) => scc_dest.destination === q);
       }
     }
     return false;

--- a/src/ida.ts
+++ b/src/ida.ts
@@ -2,25 +2,25 @@ import { buildStronglyConnectedComponents } from './scc';
 import { TripleDirectProductNFA, Message } from './types';
 
 export function showMessageIDA(tdps: TripleDirectProductNFA[]): Message {
-	if (tdps.some((tdp) => isIDA(tdp))) {
-		return { status: 'Vulnerable', message: 'Detected IDA.' };
-	} else {
-		return { status: 'Safe', message: 'Don\'t have IDA.' };
-	}
+  if (tdps.some((tdp) => isIDA(tdp))) {
+    return { status: 'Vulnerable', message: 'Detected IDA.' };
+  } else {
+    return { status: 'Safe', message: 'Don\'t have IDA.' };
+  }
 }
 
 function isIDA(tdp: TripleDirectProductNFA): boolean {
-	const sccs = buildStronglyConnectedComponents(tdp);
-	return sccs.some((scc) => {
-		// 追加辺 (q1, q2, q2) => (q1, q1, q2) に対応する辺 (q1, q1, q2) => (q1, q2, q2) が強連結成分内の辺として存在するかどうかを判定
+  const sccs = buildStronglyConnectedComponents(tdp);
+  return sccs.some((scc) => {
+    // 追加辺 (q1, q2, q2) => (q1, q1, q2) に対応する辺 (q1, q1, q2) => (q1, q2, q2) が強連結成分内の辺として存在するかどうかを判定
 
-		for (const [q, ts] of tdp.extraTransitions) {
-			for (const t of ts) {
-				return scc.transitions.get(t.destination)?.some(
-					(scc_dest) => scc_dest.destination === q
-				);
-			}
-		}
-		return false;
-	});
+    for (const [q, ts] of tdp.extraTransitions) {
+      for (const t of ts) {
+        return scc.transitions.get(t.destination)?.some(
+          (scc_dest) => scc_dest.destination === q
+        );
+      }
+    }
+    return false;
+  });
 }

--- a/src/ida.ts
+++ b/src/ida.ts
@@ -1,0 +1,26 @@
+import { buildStronglyConnectedComponents } from './scc';
+import { TripleDirectProductNFA, Message } from './types';
+
+export function showMessageIDA(tdps: TripleDirectProductNFA[]): Message {
+	if (tdps.some((tdp) => isIDA(tdp))) {
+		return { status: 'Vulnerable', message: 'Detected IDA.' };
+	} else {
+		return { status: 'Safe', message: 'Don\'t have IDA.' };
+	}
+}
+
+function isIDA(tdp: TripleDirectProductNFA): boolean {
+	const sccs = buildStronglyConnectedComponents(tdp);
+	return sccs.some((scc) => {
+		// 追加辺 (q1, q2, q2) => (q1, q1, q2) に対応する辺 (q1, q1, q2) => (q1, q2, q2) が強連結成分内の辺として存在するかどうかを判定
+
+		for (const [q, ts] of tdp.extraTransitions) {
+			for (const t of ts) {
+				return scc.transitions.get(t.destination)?.some(
+					(scc_dest) => scc_dest.destination === q
+				);
+			}
+		}
+		return false;
+	});
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -6,6 +6,8 @@ import { toDOT } from './viz';
 import { buildDirectProductNFAs } from './directProduct';
 import { buildStronglyConnectedComponents } from './scc';
 import { showMessageEDA } from './eda';
+import { buildTripleDirectProductNFA, buildTripleDirectProductNFAs } from './tripleDirectProduct';
+import { showMessageIDA } from './ida';
 
 function main() {
   const sources: [source: string, flags?: string][] = [
@@ -25,6 +27,7 @@ function main() {
     [String.raw`(.*)="(.*)"`],
     [String.raw`[a-z][0-9a-z]*`],
     [String.raw`a[a-z]`, 'i'],
+    [String.raw`a*a*`], // IDA典型例
   ];
 
   for (const [src, flags] of sources) {
@@ -43,6 +46,9 @@ function main() {
       console.log(toDOT(dp));
     }
     console.log(`//`, src, `has EDA?: `, showMessageEDA(dps));
+    console.log('//', src, `triple direct product`);
+    const tdps = buildTripleDirectProductNFAs(sccs, nfa);
+    console.log(`//`, src, `has IDA?: `, showMessageIDA(tdps));
     console.log(`//`, src, `reversed`);
     const rnfa = reverseNFA(nfa);
     console.log(toDOT(rnfa));

--- a/src/test.ts
+++ b/src/test.ts
@@ -6,7 +6,10 @@ import { toDOT } from './viz';
 import { buildDirectProductNFAs } from './directProduct';
 import { buildStronglyConnectedComponents } from './scc';
 import { showMessageEDA } from './eda';
-import { buildTripleDirectProductNFA, buildTripleDirectProductNFAs } from './tripleDirectProduct';
+import {
+  buildTripleDirectProductNFA,
+  buildTripleDirectProductNFAs,
+} from './tripleDirectProduct';
 import { showMessageIDA } from './ida';
 
 function main() {

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -6,8 +6,10 @@ import {
   NonNullableTransition,
   StronglyConnectedComponentNFA,
 } from './types';
-import { enumerateCharset } from './char';
-import { intersect } from './util';
+import { 
+  enumerateCharset,
+  intersectCharSets
+} from './char';
 
 export function buildTripleDirectProductNFAs(
   sccs: StronglyConnectedComponentNFA[],
@@ -150,31 +152,8 @@ class TripleDirectProducer {
                   );
                 }
 
-                // 積集合をとる
-                const le = enumerateCharset(ld.charSet);
-                const ce = enumerateCharset(cd.charSet);
-                const re = enumerateCharset(rd.charSet);
-
-                const lcre = Array.from(intersect(le, intersect(ce, re))).sort(
-                  (a, b) => a - b,
-                );
-
-                if (lcre.length > 0) {
-                  const data = [];
-
-                  data.push(lcre[0]);
-                  // 連続した文字コード数字列を１つにまとめる
-                  for (let i = 0; i < lcre.length - 1; i++) {
-                    if (lcre[i + 1] - lcre[i] > 1) {
-                      data.push(lcre[i] + 1);
-                      data.push(lcre[i + 1]);
-                    }
-                  }
-                  data.push(lcre[lcre.length - 1] + 1);
-
-                  const charSet = new CharSet(data);
-                  this.addTransition(source, charSet, dest);
-                }
+                const lcre = intersectCharSets(ld.charSet, cd.charSet, rd.charSet);
+                this.addTransition(source, lcre, dest);
               }
             }
           }

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -1,30 +1,30 @@
 import { CharSet } from 'rerejs';
 import {
-	TripleDirectProductNFA,
-	SCCPossibleAutomaton,
-	State,
-	NonNullableTransition,
-	StronglyConnectedComponentNFA,
+  TripleDirectProductNFA,
+  SCCPossibleAutomaton,
+  State,
+  NonNullableTransition,
+  StronglyConnectedComponentNFA,
 } from './types';
 import { enumerateCharset } from './char';
 import { intersect } from './util';
 
 export function buildTripleDirectProductNFAs(
-	sccs: StronglyConnectedComponentNFA[],
-	nfa: SCCPossibleAutomaton,
+  sccs: StronglyConnectedComponentNFA[],
+  nfa: SCCPossibleAutomaton,
 ): TripleDirectProductNFA[] {
-	return sccs.map((scc1, index, sccs) => 
-		sccs.filter(scc2 => scc1 !== scc2)
-		.map(scc2 => buildTripleDirectProductNFA(scc1, scc2, nfa)
-	)).flat(1);
+  return sccs.map((scc1, index, sccs) => 
+    sccs.filter(scc2 => scc1 !== scc2)
+    .map(scc2 => buildTripleDirectProductNFA(scc1, scc2, nfa)
+  )).flat(1);
 }
 
 export function buildTripleDirectProductNFA(
-	sccNFA1: StronglyConnectedComponentNFA,
-	sccNFA2: StronglyConnectedComponentNFA,
-	nfa: SCCPossibleAutomaton,
+  sccNFA1: StronglyConnectedComponentNFA,
+  sccNFA2: StronglyConnectedComponentNFA,
+  nfa: SCCPossibleAutomaton,
 ): TripleDirectProductNFA {
-	return new TripleDirectProducer(sccNFA1, sccNFA2, nfa).build();
+  return new TripleDirectProducer(sccNFA1, sccNFA2, nfa).build();
 }
 
 export function getLeftString(state: State): string {
@@ -38,179 +38,179 @@ export function getRightString(state: State): string {
 class TripleDirectProducer {
   private newStateList: State[] = [];
   private newTransitions: Map<State, NonNullableTransition[]> = new Map();
-	private newStateToOldStateSet: Map<State, [State, State, State]> = new Map();
-	private extraTransitions: Map<State, NonNullableTransition[]> = new Map();
+  private newStateToOldStateSet: Map<State, [State, State, State]> = new Map();
+  private extraTransitions: Map<State, NonNullableTransition[]> = new Map();
 
-	constructor(
-		private sccNFA1: StronglyConnectedComponentNFA,
-		private sccNFA2: StronglyConnectedComponentNFA,
-		private nfa: SCCPossibleAutomaton,
-	) {}
+  constructor(
+    private sccNFA1: StronglyConnectedComponentNFA,
+    private sccNFA2: StronglyConnectedComponentNFA,
+    private nfa: SCCPossibleAutomaton,
+  ) {}
 
-	build(): TripleDirectProductNFA {
-		// 強連結成分scc1, scc2間のTransitionsを取得する
-		const betweenTransitionsSCC: Map<State, NonNullableTransition[]> = new Map();
-		for (const s1 of this.sccNFA1.stateList) {
-			for (const s1t of this.nfa.transitions.get(s1)!) {
-				if(this.sccNFA2.stateList.some(dest => dest.id === s1t.destination.id)){
-					if(betweenTransitionsSCC.get(s1)! === undefined)
-						betweenTransitionsSCC.set(s1, []);
-					betweenTransitionsSCC.get(s1)!.push(s1t);
-				}
-			}
-		}
-		for (const s2 of this.sccNFA2.stateList) {
-			for (const s2t of this.sccNFA2.transitions.get(s2)!) {
-				if(this.sccNFA1.stateList.some(dest => dest.id === s2t.destination.id)){
-					if(betweenTransitionsSCC.get(s2)! === undefined)
-						betweenTransitionsSCC.set(s2, []);
-					betweenTransitionsSCC.get(s2)!.push(s2t);
-				}
-			}
-		}
+  build(): TripleDirectProductNFA {
+    // 強連結成分scc1, scc2間のTransitionsを取得する
+    const betweenTransitionsSCC: Map<State, NonNullableTransition[]> = new Map();
+    for (const s1 of this.sccNFA1.stateList) {
+      for (const s1t of this.nfa.transitions.get(s1)!) {
+        if(this.sccNFA2.stateList.some(dest => dest.id === s1t.destination.id)){
+          if(betweenTransitionsSCC.get(s1)! === undefined)
+            betweenTransitionsSCC.set(s1, []);
+          betweenTransitionsSCC.get(s1)!.push(s1t);
+        }
+      }
+    }
+    for (const s2 of this.sccNFA2.stateList) {
+      for (const s2t of this.sccNFA2.transitions.get(s2)!) {
+        if(this.sccNFA1.stateList.some(dest => dest.id === s2t.destination.id)){
+          if(betweenTransitionsSCC.get(s2)! === undefined)
+            betweenTransitionsSCC.set(s2, []);
+          betweenTransitionsSCC.get(s2)!.push(s2t);
+        }
+      }
+    }
 
-		// 後々のループのネストを浅くするため、2つのsccNFAの和集合を作る
-		const sumOfTwoSccStateList: Set<State> = new Set();
-		for (const s1 of this.sccNFA1.stateList) {
-			sumOfTwoSccStateList.add(s1);
-		}
-		for (const s2 of this.sccNFA2.stateList) {
-			sumOfTwoSccStateList.add(s2);
-		}
-		for (const ls of sumOfTwoSccStateList) {
-			for (const cs of sumOfTwoSccStateList) {
-				for (const rs of sumOfTwoSccStateList) {
-					this.createState(ls, cs, rs);
-				}
-			}
-		}
-		
-		const sumOfTwoSccTransitions: Map<State, NonNullableTransition[]> = new Map();
-		for (const [q, ds] of this.sccNFA1.transitions) {
-			for (const d of ds) {
-				if(sumOfTwoSccTransitions.get(q)! === undefined)
-					sumOfTwoSccTransitions.set(q, []);
-				sumOfTwoSccTransitions.get(q)!.push(d);
-			}
-		} 
-		for (const [q, ds] of this.sccNFA2.transitions) {
-			for (const d of ds) {
-				if(sumOfTwoSccTransitions.get(q)! === undefined)
-					sumOfTwoSccTransitions.set(q, []);
-				sumOfTwoSccTransitions.get(q)!.push(d);
-			}
-		} 
-		for (const [q, ds] of betweenTransitionsSCC) {
-			for (const d of ds) {
-				if(sumOfTwoSccTransitions.get(q)! === undefined)
-					sumOfTwoSccTransitions.set(q, []);
-				sumOfTwoSccTransitions.get(q)!.push(d);
-			}
-		}
+    // 後々のループのネストを浅くするため、2つのsccNFAの和集合を作る
+    const sumOfTwoSccStateList: Set<State> = new Set();
+    for (const s1 of this.sccNFA1.stateList) {
+      sumOfTwoSccStateList.add(s1);
+    }
+    for (const s2 of this.sccNFA2.stateList) {
+      sumOfTwoSccStateList.add(s2);
+    }
+    for (const ls of sumOfTwoSccStateList) {
+      for (const cs of sumOfTwoSccStateList) {
+        for (const rs of sumOfTwoSccStateList) {
+          this.createState(ls, cs, rs);
+        }
+      }
+    }
+    
+    const sumOfTwoSccTransitions: Map<State, NonNullableTransition[]> = new Map();
+    for (const [q, ds] of this.sccNFA1.transitions) {
+      for (const d of ds) {
+        if(sumOfTwoSccTransitions.get(q)! === undefined)
+          sumOfTwoSccTransitions.set(q, []);
+        sumOfTwoSccTransitions.get(q)!.push(d);
+      }
+    } 
+    for (const [q, ds] of this.sccNFA2.transitions) {
+      for (const d of ds) {
+        if(sumOfTwoSccTransitions.get(q)! === undefined)
+          sumOfTwoSccTransitions.set(q, []);
+        sumOfTwoSccTransitions.get(q)!.push(d);
+      }
+    } 
+    for (const [q, ds] of betweenTransitionsSCC) {
+      for (const d of ds) {
+        if(sumOfTwoSccTransitions.get(q)! === undefined)
+          sumOfTwoSccTransitions.set(q, []);
+        sumOfTwoSccTransitions.get(q)!.push(d);
+      }
+    }
 
-		for (const [lq, lds] of sumOfTwoSccTransitions) {
-			for (const ld of lds) {
-				for (const [cq, cds] of sumOfTwoSccTransitions) {
-					for (const cd of cds) {
-						for (const [rq, rds] of sumOfTwoSccTransitions) {
-							for (const rd of rds) {
-								let source = this.getState(lq, cq, rq);
-								if(source === null) {
-									source = this.createState(lq, cq, rq);
-								}
+    for (const [lq, lds] of sumOfTwoSccTransitions) {
+      for (const ld of lds) {
+        for (const [cq, cds] of sumOfTwoSccTransitions) {
+          for (const cd of cds) {
+            for (const [rq, rds] of sumOfTwoSccTransitions) {
+              for (const rd of rds) {
+                let source = this.getState(lq, cq, rq);
+                if(source === null) {
+                  source = this.createState(lq, cq, rq);
+                }
 
-								let dest = this.getState(ld.destination, cd.destination, rd.destination);
-								if(dest === null) {
-									dest = this.createState(ld.destination, cd.destination, rd.destination);
-								}
+                let dest = this.getState(ld.destination, cd.destination, rd.destination);
+                if(dest === null) {
+                  dest = this.createState(ld.destination, cd.destination, rd.destination);
+                }
 
-								// 積集合をとる
-								const le = enumerateCharset(ld.charSet);
-								const ce = enumerateCharset(cd.charSet);
-								const re = enumerateCharset(rd.charSet);
+                // 積集合をとる
+                const le = enumerateCharset(ld.charSet);
+                const ce = enumerateCharset(cd.charSet);
+                const re = enumerateCharset(rd.charSet);
 
-								const lcre = Array.from(intersect(le, intersect(ce, re))).sort((a, b) => a - b);
+                const lcre = Array.from(intersect(le, intersect(ce, re))).sort((a, b) => a - b);
 
-								if (lcre.length > 0) {
-									const data = [];
-									
-									data.push(lcre[0]);
-									// 連続した文字コード数字列を１つにまとめる
-									for (let i = 0; i < lcre.length - 1; i++) {
-										if (lcre[i + 1] - lcre[i] > 1) {
-										data.push(lcre[i] + 1);
-										data.push(lcre[i + 1]);
-										}
-									}
-									data.push(lcre[lcre.length - 1] + 1);
-									
-									const charSet = new CharSet(data);
-									this.addTransition(source, charSet, dest);
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		
-		// IDA判定のために、強連結成分間の戻る辺を追加
-		for (const [s, dests] of betweenTransitionsSCC) {
-			for (const d of dests) {
-				let exs = this.getState(s, d.destination, d.destination);
-				if(exs === null) {
-					exs = this.createState(s, d.destination, d.destination);
-				}
+                if (lcre.length > 0) {
+                  const data = [];
+                  
+                  data.push(lcre[0]);
+                  // 連続した文字コード数字列を１つにまとめる
+                  for (let i = 0; i < lcre.length - 1; i++) {
+                    if (lcre[i + 1] - lcre[i] > 1) {
+                    data.push(lcre[i] + 1);
+                    data.push(lcre[i + 1]);
+                    }
+                  }
+                  data.push(lcre[lcre.length - 1] + 1);
+                  
+                  const charSet = new CharSet(data);
+                  this.addTransition(source, charSet, dest);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    
+    // IDA判定のために、強連結成分間の戻る辺を追加
+    for (const [s, dests] of betweenTransitionsSCC) {
+      for (const d of dests) {
+        let exs = this.getState(s, d.destination, d.destination);
+        if(exs === null) {
+          exs = this.createState(s, d.destination, d.destination);
+        }
 
-				let exd = this.getState(s, s, d.destination);
-				if(exd === null) {
-					exd = this.createState(s, s, d.destination);
-				}
+        let exd = this.getState(s, s, d.destination);
+        if(exd === null) {
+          exd = this.createState(s, s, d.destination);
+        }
 
-				this.newTransitions.get(
-					[...this.newTransitions.keys()].filter(nt => nt.id === exs!.id)[0]
-				)!.push({charSet: d.charSet, destination: exd});
+        this.newTransitions.get(
+          [...this.newTransitions.keys()].filter(nt => nt.id === exs!.id)[0]
+        )!.push({charSet: d.charSet, destination: exd});
 
-				if(this.extraTransitions.get(exs)! === undefined)
-					this.extraTransitions.set(exs, []);
-				this.extraTransitions.get(exs)!.push({charSet: d.charSet, destination: exd});
-			};
-		}
+        if(this.extraTransitions.get(exs)! === undefined)
+          this.extraTransitions.set(exs, []);
+        this.extraTransitions.get(exs)!.push({charSet: d.charSet, destination: exd});
+      };
+    }
 
-		return {
-			type: 'TripleDirectProductNFA',
-			stateList: this.newStateList,
-			transitions: this.newTransitions,
-			extraTransitions: this.extraTransitions,
-		}
-	}
+    return {
+      type: 'TripleDirectProductNFA',
+      stateList: this.newStateList,
+      transitions: this.newTransitions,
+      extraTransitions: this.extraTransitions,
+    }
+  }
 
-	getState(leftState: State, centerState: State, rightState: State): State | null {
-		for (const [ns, os] of this.newStateToOldStateSet) {
-			if (os[0] === leftState && os[1] === centerState && os[2] === rightState) {
-				return ns;
-			}
-		}
-		return null;
-	}
+  getState(leftState: State, centerState: State, rightState: State): State | null {
+    for (const [ns, os] of this.newStateToOldStateSet) {
+      if (os[0] === leftState && os[1] === centerState && os[2] === rightState) {
+        return ns;
+      }
+    }
+    return null;
+  }
 
-	// 直積は前の状態をスペース区切りに
-	createState(leftState: State, centerState: State, rightState: State): State {
-		const state: State = {
-			id: `${leftState.id}_${centerState.id}_${rightState.id}`,
-		};
+  // 直積は前の状態をスペース区切りに
+  createState(leftState: State, centerState: State, rightState: State): State {
+    const state: State = {
+      id: `${leftState.id}_${centerState.id}_${rightState.id}`,
+    };
 
-		this.newStateList.push(state);
+    this.newStateList.push(state);
     this.newTransitions.set(state, []);
     this.newStateToOldStateSet.set(state, [leftState, centerState, rightState]);
     return state;
-	}
+  }
 
-	private addTransition(
-		source: State,
-		charSet: CharSet,
-		destination: State,
-	): void {
-		this.newTransitions.get(source)!.push({ charSet, destination });
-	}
+  private addTransition(
+    source: State,
+    charSet: CharSet,
+    destination: State,
+  ): void {
+    this.newTransitions.get(source)!.push({ charSet, destination });
+  }
 }

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -1,4 +1,5 @@
 import { CharSet } from 'rerejs';
+import { intersectCharSets } from './char';
 import {
   TripleDirectProductNFA,
   SCCPossibleAutomaton,
@@ -6,10 +7,6 @@ import {
   NonNullableTransition,
   StronglyConnectedComponentNFA,
 } from './types';
-import { 
-  enumerateCharset,
-  intersectCharSets
-} from './char';
 
 export function buildTripleDirectProductNFAs(
   sccs: StronglyConnectedComponentNFA[],
@@ -152,7 +149,11 @@ class TripleDirectProducer {
                   );
                 }
 
-                const lcre = intersectCharSets(ld.charSet, cd.charSet, rd.charSet);
+                const lcre = intersectCharSets(
+                  ld.charSet,
+                  cd.charSet,
+                  rd.charSet,
+                );
                 this.addTransition(source, lcre, dest);
               }
             }

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -13,10 +13,13 @@ export function buildTripleDirectProductNFAs(
   sccs: StronglyConnectedComponentNFA[],
   nfa: SCCPossibleAutomaton,
 ): TripleDirectProductNFA[] {
-  return sccs.map((scc1, index, sccs) => 
-    sccs.filter(scc2 => scc1 !== scc2)
-    .map(scc2 => buildTripleDirectProductNFA(scc1, scc2, nfa)
-  )).flat(1);
+  return sccs
+    .map((scc1, _, sccs) =>
+      sccs
+        .filter((scc2) => scc1 !== scc2)
+        .map((scc2) => buildTripleDirectProductNFA(scc1, scc2, nfa)),
+    )
+    .flat(1);
 }
 
 export function buildTripleDirectProductNFA(
@@ -25,14 +28,6 @@ export function buildTripleDirectProductNFA(
   nfa: SCCPossibleAutomaton,
 ): TripleDirectProductNFA {
   return new TripleDirectProducer(sccNFA1, sccNFA2, nfa).build();
-}
-
-export function getLeftString(state: State): string {
-  return state.id.split('_')[0];
-}
-
-export function getRightString(state: State): string {
-  return state.id.split('_')[1];
 }
 
 class TripleDirectProducer {
@@ -49,21 +44,32 @@ class TripleDirectProducer {
 
   build(): TripleDirectProductNFA {
     // 強連結成分scc1, scc2間のTransitionsを取得する
-    const betweenTransitionsSCC: Map<State, NonNullableTransition[]> = new Map();
+    const betweenTransitionsSCC: Map<
+      State,
+      NonNullableTransition[]
+    > = new Map();
+
     for (const s1 of this.sccNFA1.stateList) {
       for (const s1t of this.nfa.transitions.get(s1)!) {
-        if(this.sccNFA2.stateList.some(dest => dest.id === s1t.destination.id)){
-          if(betweenTransitionsSCC.get(s1)! === undefined)
+        if (
+          this.sccNFA2.stateList.some((dest) => dest.id === s1t.destination.id)
+        ) {
+          if (betweenTransitionsSCC.get(s1)! === undefined) {
             betweenTransitionsSCC.set(s1, []);
+          }
           betweenTransitionsSCC.get(s1)!.push(s1t);
         }
       }
     }
+
     for (const s2 of this.sccNFA2.stateList) {
       for (const s2t of this.sccNFA2.transitions.get(s2)!) {
-        if(this.sccNFA1.stateList.some(dest => dest.id === s2t.destination.id)){
-          if(betweenTransitionsSCC.get(s2)! === undefined)
+        if (
+          this.sccNFA1.stateList.some((dest) => dest.id === s2t.destination.id)
+        ) {
+          if (betweenTransitionsSCC.get(s2)! === undefined) {
             betweenTransitionsSCC.set(s2, []);
+          }
           betweenTransitionsSCC.get(s2)!.push(s2t);
         }
       }
@@ -71,12 +77,15 @@ class TripleDirectProducer {
 
     // 後々のループのネストを浅くするため、2つのsccNFAの和集合を作る
     const sumOfTwoSccStateList: Set<State> = new Set();
+
     for (const s1 of this.sccNFA1.stateList) {
       sumOfTwoSccStateList.add(s1);
     }
+
     for (const s2 of this.sccNFA2.stateList) {
       sumOfTwoSccStateList.add(s2);
     }
+
     for (const ls of sumOfTwoSccStateList) {
       for (const cs of sumOfTwoSccStateList) {
         for (const rs of sumOfTwoSccStateList) {
@@ -84,26 +93,35 @@ class TripleDirectProducer {
         }
       }
     }
-    
-    const sumOfTwoSccTransitions: Map<State, NonNullableTransition[]> = new Map();
+
+    const sumOfTwoSccTransitions: Map<
+      State,
+      NonNullableTransition[]
+    > = new Map();
+
     for (const [q, ds] of this.sccNFA1.transitions) {
       for (const d of ds) {
-        if(sumOfTwoSccTransitions.get(q)! === undefined)
+        if (sumOfTwoSccTransitions.get(q)! === undefined) {
           sumOfTwoSccTransitions.set(q, []);
+        }
         sumOfTwoSccTransitions.get(q)!.push(d);
       }
-    } 
+    }
+
     for (const [q, ds] of this.sccNFA2.transitions) {
       for (const d of ds) {
-        if(sumOfTwoSccTransitions.get(q)! === undefined)
+        if (sumOfTwoSccTransitions.get(q)! === undefined) {
           sumOfTwoSccTransitions.set(q, []);
+        }
         sumOfTwoSccTransitions.get(q)!.push(d);
       }
-    } 
+    }
+
     for (const [q, ds] of betweenTransitionsSCC) {
       for (const d of ds) {
-        if(sumOfTwoSccTransitions.get(q)! === undefined)
+        if (sumOfTwoSccTransitions.get(q)! === undefined) {
           sumOfTwoSccTransitions.set(q, []);
+        }
         sumOfTwoSccTransitions.get(q)!.push(d);
       }
     }
@@ -115,13 +133,21 @@ class TripleDirectProducer {
             for (const [rq, rds] of sumOfTwoSccTransitions) {
               for (const rd of rds) {
                 let source = this.getState(lq, cq, rq);
-                if(source === null) {
+                if (source === null) {
                   source = this.createState(lq, cq, rq);
                 }
 
-                let dest = this.getState(ld.destination, cd.destination, rd.destination);
-                if(dest === null) {
-                  dest = this.createState(ld.destination, cd.destination, rd.destination);
+                let dest = this.getState(
+                  ld.destination,
+                  cd.destination,
+                  rd.destination,
+                );
+                if (dest === null) {
+                  dest = this.createState(
+                    ld.destination,
+                    cd.destination,
+                    rd.destination,
+                  );
                 }
 
                 // 積集合をとる
@@ -129,21 +155,23 @@ class TripleDirectProducer {
                 const ce = enumerateCharset(cd.charSet);
                 const re = enumerateCharset(rd.charSet);
 
-                const lcre = Array.from(intersect(le, intersect(ce, re))).sort((a, b) => a - b);
+                const lcre = Array.from(intersect(le, intersect(ce, re))).sort(
+                  (a, b) => a - b,
+                );
 
                 if (lcre.length > 0) {
                   const data = [];
-                  
+
                   data.push(lcre[0]);
                   // 連続した文字コード数字列を１つにまとめる
                   for (let i = 0; i < lcre.length - 1; i++) {
                     if (lcre[i + 1] - lcre[i] > 1) {
-                    data.push(lcre[i] + 1);
-                    data.push(lcre[i + 1]);
+                      data.push(lcre[i] + 1);
+                      data.push(lcre[i + 1]);
                     }
                   }
                   data.push(lcre[lcre.length - 1] + 1);
-                  
+
                   const charSet = new CharSet(data);
                   this.addTransition(source, charSet, dest);
                 }
@@ -153,28 +181,35 @@ class TripleDirectProducer {
         }
       }
     }
-    
+
     // IDA判定のために、強連結成分間の戻る辺を追加
     for (const [s, dests] of betweenTransitionsSCC) {
       for (const d of dests) {
         let exs = this.getState(s, d.destination, d.destination);
-        if(exs === null) {
+        if (exs === null) {
           exs = this.createState(s, d.destination, d.destination);
         }
 
         let exd = this.getState(s, s, d.destination);
-        if(exd === null) {
+        if (exd === null) {
           exd = this.createState(s, s, d.destination);
         }
 
-        this.newTransitions.get(
-          [...this.newTransitions.keys()].filter(nt => nt.id === exs!.id)[0]
-        )!.push({charSet: d.charSet, destination: exd});
+        this.newTransitions
+          .get(
+            [...this.newTransitions.keys()].filter(
+              (nt) => nt.id === exs!.id,
+            )[0],
+          )!
+          .push({ charSet: d.charSet, destination: exd });
 
-        if(this.extraTransitions.get(exs)! === undefined)
+        if (this.extraTransitions.get(exs)! === undefined) {
           this.extraTransitions.set(exs, []);
-        this.extraTransitions.get(exs)!.push({charSet: d.charSet, destination: exd});
-      };
+        }
+        this.extraTransitions
+          .get(exs)!
+          .push({ charSet: d.charSet, destination: exd });
+      }
     }
 
     return {
@@ -182,12 +217,20 @@ class TripleDirectProducer {
       stateList: this.newStateList,
       transitions: this.newTransitions,
       extraTransitions: this.extraTransitions,
-    }
+    };
   }
 
-  getState(leftState: State, centerState: State, rightState: State): State | null {
+  getState(
+    leftState: State,
+    centerState: State,
+    rightState: State,
+  ): State | null {
     for (const [ns, os] of this.newStateToOldStateSet) {
-      if (os[0] === leftState && os[1] === centerState && os[2] === rightState) {
+      if (
+        os[0] === leftState &&
+        os[1] === centerState &&
+        os[2] === rightState
+      ) {
         return ns;
       }
     }

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -1,0 +1,128 @@
+import { CharSet } from 'rerejs';
+import {
+	TripleDirectProductNFA,
+	State,
+	NonNullableTransition,
+	StronglyConnectedComponentNFA,
+} from './types';
+import { enumerateCharset } from './char';
+import { intersect } from './util';
+
+export function buildTripleDirectProductNFAs(
+	sccs: StronglyConnectedComponentNFA[],
+): TripleDirectProductNFA[] {
+	return sccs.map((scc) => buildTripleDirectProductNFA(scc));
+}
+
+export function buildTripleDirectProductNFA(
+	sccNFA: StronglyConnectedComponentNFA,
+): TripleDirectProductNFA {
+	return new TripleDirectProducer(sccNFA).build();
+}
+
+export function getLeftString(state: State): string {
+  return state.id.split('_')[0];
+}
+
+export function getRightString(state: State): string {
+  return state.id.split('_')[1];
+}
+
+class TripleDirectProducer {
+  private newStateList: State[] = [];
+  private newTransitions: Map<State, NonNullableTransition[]> = new Map();
+  private newStateToOldStateSet: Map<State, [State, State, State]> = new Map();
+
+	constructor(private sccNFA: StronglyConnectedComponentNFA) {}
+
+	build(): TripleDirectProductNFA {
+		for (const ls of this.sccNFA.stateList) {
+			for (const cs of this.sccNFA.stateList) {
+				for (const rs of this.sccNFA.stateList) {
+					this.createState(ls, cs, rs);
+				}
+			}
+		}
+
+		for (const [lq, lds] of this.sccNFA.transitions) {
+			for (const ld of lds) {
+				for (const [cq, cds] of this.sccNFA.transitions) {
+					for (const cd of cds) {
+						for (const [rq, rds] of this.sccNFA.transitions) {
+							for (const rd of rds) {
+								let source = this.getState(lq, cq, rq);
+								if(source === null) {
+									source = this.createState(lq, cq, rq);
+								}
+
+								let dest = this.getState(ld.destination, cd.destination, rd.destination);
+								if(dest === null) {
+									dest = this.createState(ld.destination, cd.destination, rd.destination);
+								}
+
+								// 積集合をとる
+								const le = enumerateCharset(ld.charSet);
+								const ce = enumerateCharset(cd.charSet);
+								const re = enumerateCharset(rd.charSet);
+
+								const lcre = Array.from(intersect(le, intersect(ce, re))).sort((a, b) => a - b);
+
+								if (lcre.length > 0) {
+									const data = [];
+									
+									data.push(lcre[0]);
+									// 連続した文字コード列を１つにまとめる
+									for (let i = 0; i < lcre.length - 1; i++) {
+										if (lcre[i + 1] - lcre[i] > 1) {
+										data.push(lcre[i] + 1);
+										data.push(lcre[i + 1]);
+										}
+									}
+									data.push(lcre[lcre.length - 1] + 1);
+									
+									const charSet = new CharSet(data);
+									this.addTransition(source, charSet, dest);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return {
+			type: 'TripleDirectProductNFA',
+			stateList: this.newStateList,
+			transitions: this.newTransitions,
+		}
+	}
+
+	getState(leftState: State, centerState: State, rightState: State): State | null {
+		for (const [ns, os] of this.newStateToOldStateSet) {
+			if (os[0] === leftState && os[1] === centerState && os[2] === rightState) {
+				return ns;
+			}
+		}
+		return null;
+	}
+
+	// 直積は前の状態をスペース区切りに
+	createState(leftState: State, centerState: State, rightState: State): State {
+		const state: State = {
+			id: `${leftState.id}_${centerState.id}_${rightState.id}`,
+		};
+
+		this.newStateList.push(state);
+    this.newTransitions.set(state, []);
+    this.newStateToOldStateSet.set(state, [leftState, centerState, rightState]);
+    return state;
+	}
+
+	private addTransition(
+		source: State,
+		charSet: CharSet,
+		destination: State,
+	): void {
+		this.newTransitions.get(source)!.push({ charSet, destination });
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,10 @@ export type Automaton =
   | DirectProductNFA
   | TripleDirectProductNFA;
 
-export type SCCPossibleAutomaton = NonEpsilonNFA | DirectProductNFA | TripleDirectProductNFA;
+export type SCCPossibleAutomaton =
+  | NonEpsilonNFA
+  | DirectProductNFA
+  | TripleDirectProductNFA;
 
 export type EpsilonNFA = {
   type: 'EpsilonNFA';
@@ -46,7 +49,7 @@ export type TripleDirectProductNFA = {
   stateList: State[];
   transitions: Map<State, NonNullableTransition[]>;
   extraTransitions: Map<State, NonNullableTransition[]>;
-}
+};
 
 export type UnorderedNFA = {
   type: 'UnorderedNFA';

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,10 @@ export type Automaton =
   | UnorderedNFA
   | DFA
   | StronglyConnectedComponentNFA
-  | DirectProductNFA;
+  | DirectProductNFA
+  | TripleDirectProductNFA;
 
-export type SCCPossibleAutomaton = NonEpsilonNFA | DirectProductNFA;
+export type SCCPossibleAutomaton = NonEpsilonNFA | DirectProductNFA | TripleDirectProductNFA;
 
 export type EpsilonNFA = {
   type: 'EpsilonNFA';
@@ -39,6 +40,13 @@ export type DirectProductNFA = {
   stateList: State[];
   transitions: Map<State, NonNullableTransition[]>;
 };
+
+export type TripleDirectProductNFA = {
+  type: 'TripleDirectProductNFA';
+  stateList: State[];
+  transitions: Map<State, NonNullableTransition[]>;
+  extraTransitions: Map<State, NonNullableTransition[]>;
+}
 
 export type UnorderedNFA = {
   type: 'UnorderedNFA';

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -54,6 +54,7 @@ export function toDOT(
   switch (automaton.type) {
     case 'StronglyConnectedComponentNFA':
     case 'DirectProductNFA':
+    case 'TripleDirectProductNFA':
       break;
     default: {
       const acceptingStateSet =


### PR DESCRIPTION
とりあえず ```a*a*```を正しく判定できるようにはできました。
ただ、テストケースの中の```(.*)="(.*)```だけは実行時間がとても長いので、計算量などを考え直す必要があります。