### PR TITLE
eslintとprettierの設定を追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,12 +5,22 @@
     "plugin:prettier/recommended"
   ],
   "rules": {
-    "no-console": 0,
     "prettier/prettier": "error",
     "@typescript-eslint/no-var-requires": 1,
-    "@typescript-eslint/explicit-function-return-type": 0,
-    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/explicit-function-return-type": 1,
+    "@typescript-eslint/no-explicit-any": 1,
     "@typescript-eslint/indent": 0,
-	"@typescript-eslint/no-non-null-assertion": 0
+	"@typescript-eslint/no-non-null-assertion": 0,
+	"for-direction": 2,
+	"curly": [2, "all"],
+	"eqeqeq": 2,
+    "no-console": 0,
+	"no-eq-null": 2,
+	"no-eval": 2,
+	"no-implicit-coercion": 2,
+	"no-cond-assign": 2,
+	"no-dupe-args": 2,
+	"no-dupe-keys": 2,
+	"no-empty": 2
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,4 +5,5 @@
   "singleQuote": true,
   "trailingComma": 'all',
   "useTabs": false,
+  "endOfLine":"lf",
 }


### PR DESCRIPTION
# WHAT

- prettierでフォーマットされるとき改行コードをlfに固定
- 1行if文でもbraceを必要に(コードの可読性を上げたい)

などなど

マージしちゃって大丈夫です