### PR TITLE
CharSet の積集合の改善

### DIFF
--- a/src/char.ts
+++ b/src/char.ts
@@ -110,3 +110,12 @@ export function enumerateCharset(charSet: CharSet): Set<number> {
   }
   return enumSet;
 }
+
+export function intersectCharSets(...charSets: CharSet[]): CharSet {
+  const intersection = new CharSet();
+  for (const cs of charSets) {
+    intersection.addCharSet(cs.clone().invert());
+  }
+  intersection.invert();
+  return intersection;
+}


### PR DESCRIPTION
現状の1文字ずつ列挙する方法では #14 で出たように `.` のときにかなり遅くなってしまうので、代替案です。

問題なければ、#14 が済んだら DirectProductNFA と TripleDirectProductNFA の方に適用しようかなと思います。