### PR TITLE
[WIP] intersectCharSets向けに直積演算を変更+bugfix

### DIFF
--- a/src/char.ts
+++ b/src/char.ts
@@ -95,6 +95,16 @@ export function canonicalize(value: number): number {
   return String.fromCharCode(value).toUpperCase().charCodeAt(0);
 }
 
+export function intersectCharSets(...charSets: CharSet[]): CharSet {
+  const intersection = new CharSet();
+  for (const cs of charSets) {
+    intersection.addCharSet(cs.clone().invert());
+  }
+  intersection.invert();
+  return intersection;
+}
+
+// WARNING: 複数のCharSetのdataの積集合を取る場合, intersectCharSets関数利用を推奨
 export function enumerateCharset(charSet: CharSet): Set<number> {
   const enumSet: Set<number> = new Set();
 
@@ -109,13 +119,4 @@ export function enumerateCharset(charSet: CharSet): Set<number> {
       });
   }
   return enumSet;
-}
-
-export function intersectCharSets(...charSets: CharSet[]): CharSet {
-  const intersection = new CharSet();
-  for (const cs of charSets) {
-    intersection.addCharSet(cs.clone().invert());
-  }
-  intersection.invert();
-  return intersection;
 }

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -5,8 +5,7 @@ import {
   NonNullableTransition,
   StronglyConnectedComponentNFA,
 } from './types';
-import { enumerateCharset } from './char';
-import { intersect } from './util';
+import { intersectCharSets } from './char';
 
 export function buildDirectProductNFAs(
   sccs: StronglyConnectedComponentNFA[],
@@ -56,25 +55,8 @@ class DirectProducer {
               dest = this.createState(ld.destination, rd.destination);
             }
 
-            // 全列挙して積集合を取る
-            const le = enumerateCharset(ld.charSet);
-            const re = enumerateCharset(rd.charSet);
-            const lre = Array.from(intersect(le, re)).sort((a, b) => a - b);
-
-            if (lre.length > 0) {
-              const data = [];
-              data.push(lre[0]);
-              for (let i = 0; i < lre.length - 1; i++) {
-                if (lre[i + 1] - lre[i] > 1) {
-                  data.push(lre[i] + 1);
-                  data.push(lre[i + 1]);
-                }
-              }
-              data.push(lre[lre.length - 1] + 1);
-
-              const charSet = new CharSet(data);
-              this.addTransition(source, charSet, dest);
-            }
+            const lrCharSet = intersectCharSets(ld.charSet, rd.charSet);
+            this.addTransition(source, lrCharSet, dest);
           }
         }
       }
@@ -89,7 +71,7 @@ class DirectProducer {
 
   getState(leftState: State, rightState: State): State | null {
     for (const [ns, os] of this.newStateToOldStateSet) {
-      if (os[0] === leftState && os[1] == rightState) {
+      if (os[0] === leftState && os[1] === rightState) {
         return ns;
       }
     }


### PR DESCRIPTION
# WHAT

- 直積グラフを作るにあたって辺のCharSetを作るのにintersectCharSetsを利用
- 比較演算で厳密等価演算子を使っていない場所が見つかったので修正

小さな修正なのでどちらか良かったらすぐマージして大丈夫です〜(と思ったが, IDAの方をマージしてからそっちも書き換えます, 少々お待ちを)