### PR TITLE
State の定義を string に変更

### DIFF
--- a/src/dfa.ts
+++ b/src/dfa.ts
@@ -103,9 +103,7 @@ class Determinizer {
   }
 
   createState(oldStateSet: Set<State>): State {
-    const state: State = {
-      id: `Q${this.newStateId++}`,
-    };
+    const state = `Q${this.newStateId++}` as State;
     this.newStateList.push(state);
     this.newTransitions.set(state, []);
     this.newStateToOldStateSet.set(state, oldStateSet);

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -19,12 +19,12 @@ export function buildDirectProductNFA(
   return new DirectProducer(sccNFA).build();
 }
 
-export function getLeftString(state: State): string {
-  return state.id.split('_')[0];
+export function getLeftState(state: State): State {
+  return state.split('_')[0] as State;
 }
 
-export function getRightString(state: State): string {
-  return state.id.split('_')[1];
+export function getRightState(state: State): State {
+  return state.split('_')[1] as State;
 }
 
 class DirectProducer {
@@ -80,9 +80,7 @@ class DirectProducer {
 
   // 直積は前の状態をスペース区切りに
   createState(leftState: State, rightState: State): State {
-    const state: State = {
-      id: `${leftState.id}_${rightState.id}`,
-    };
+    const state = `${leftState}_${rightState}` as State;
 
     this.newStateList.push(state);
     this.newTransitions.set(state, []);

--- a/src/eda.ts
+++ b/src/eda.ts
@@ -1,4 +1,4 @@
-import { getLeftString, getRightString } from './directProduct';
+import { getLeftState, getRightState } from './directProduct';
 import { buildStronglyConnectedComponents } from './scc';
 import { DirectProductNFA, Message } from './types';
 
@@ -35,7 +35,7 @@ function isEDA(dp: DirectProductNFA): boolean {
     }
 
     const lrSame = scc.stateList.filter(
-      (state) => getLeftString(state) === getRightString(state),
+      (state) => getLeftState(state) === getRightState(state),
     );
     // (n, n), (m, k) (m !== k)が存在(すべて同じじゃないが全て異なるわけではない)
     return lrSame.length < scc.stateList.length && lrSame.length > 0;

--- a/src/enfa.ts
+++ b/src/enfa.ts
@@ -149,9 +149,7 @@ class Builder {
   }
 
   private createState(): State {
-    const state: State = {
-      id: `q${this.stateId++}`,
-    };
+    const state = `q${this.stateId++}` as State;
     this.stateList.push(state);
     this.transitions.set(state, []);
     return state;

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -50,9 +50,7 @@ class TripleDirectProducer {
 
     for (const s1 of this.sccNFA1.stateList) {
       for (const s1t of this.nfa.transitions.get(s1)!) {
-        if (
-          this.sccNFA2.stateList.some((dest) => dest.id === s1t.destination.id)
-        ) {
+        if (this.sccNFA2.stateList.includes(s1t.destination)) {
           if (betweenTransitionsSCC.get(s1)! === undefined) {
             betweenTransitionsSCC.set(s1, []);
           }
@@ -63,9 +61,7 @@ class TripleDirectProducer {
 
     for (const s2 of this.sccNFA2.stateList) {
       for (const s2t of this.sccNFA2.transitions.get(s2)!) {
-        if (
-          this.sccNFA1.stateList.some((dest) => dest.id === s2t.destination.id)
-        ) {
+        if (this.sccNFA1.stateList.includes(s2t.destination)) {
           if (betweenTransitionsSCC.get(s2)! === undefined) {
             betweenTransitionsSCC.set(s2, []);
           }
@@ -176,11 +172,7 @@ class TripleDirectProducer {
         }
 
         this.newTransitions
-          .get(
-            [...this.newTransitions.keys()].filter(
-              (nt) => nt.id === exs!.id,
-            )[0],
-          )!
+          .get(exs)!
           .push({ charSet: d.charSet, destination: exd });
 
         if (this.extraTransitions.get(exs)! === undefined) {
@@ -219,9 +211,7 @@ class TripleDirectProducer {
 
   // 直積は前の状態をスペース区切りに
   createState(leftState: State, centerState: State, rightState: State): State {
-    const state: State = {
-      id: `${leftState.id}_${centerState.id}_${rightState.id}`,
-    };
+    const state = `${leftState}_${centerState}_${rightState}` as State;
 
     this.newStateList.push(state);
     this.newTransitions.set(state, []);

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,9 +69,7 @@ export type DFA = {
   transitions: Map<State, NonNullableTransition[]>;
 };
 
-export type State = {
-  id: string;
-};
+export type State = string & { __stateBrand: never };
 
 export type Atom = Char | EscapeClass | Class | Dot;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,13 @@ export type DFA = {
   transitions: Map<State, NonNullableTransition[]>;
 };
 
+/**
+ * 通常の string と区別する。
+ * State となる文字列は以下のフォーマットを満たす必要がある。
+ * - 単なる状態のとき、'q' + (非負整数) となる。
+ * - 状態のタプルを新たに状態とするとき、各要素を '_' で連結したものとなる。
+ * - 状態の集合を新たに状態とするとき、未定。
+ */
 export type State = string & { __stateBrand: never };
 
 export type Atom = Char | EscapeClass | Class | Dot;

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -34,12 +34,12 @@ export function toDOT(
     }
   })();
   const edges: Edge[] = [];
-  for (const [q, ds] of automaton.transitions) {
+  for (const [source, ds] of automaton.transitions) {
     for (let i = 0; i < ds.length; i++) {
       const d = ds[i];
       edges.push({
-        source: q.id,
-        destination: d.destination.id,
+        source,
+        destination: d.destination,
         priority: ordered ? i + 1 : null,
         label: toLabelString(d.charSet),
       });
@@ -63,7 +63,7 @@ export function toDOT(
           : automaton.acceptingStateSet;
       for (const q of automaton.stateList) {
         const shape = acceptingStateSet.has(q) ? `doublecircle` : `circle`;
-        out += `    ${q.id} [shape = ${shape}];\n`;
+        out += `    ${q} [shape = ${shape}];\n`;
       }
       const initialStateList =
         automaton.type === 'UnorderedNFA'
@@ -72,8 +72,8 @@ export function toDOT(
       for (let i = 0; i < initialStateList.length; i++) {
         const q = initialStateList[i];
         const priority = i + 1;
-        out += `    ${q.id}_init [shape = point];\n`;
-        out += `    ${q.id}_init -> ${q.id}${
+        out += `    ${q}_init [shape = point];\n`;
+        out += `    ${q}_init -> ${q}${
           ordered ? ` [taillabel = "${priority}"]` : ``
         };\n`;
       }


### PR DESCRIPTION
たびたび問題になっていたことなので、 `State` の定義を変更します。

今のところ最低限の部分を置き換えただけです。`State` がプリミティブになることでアルゴリズム的に改善できる部分があれば、このブランチ上で改善していってもいいかなと思います。

定義が `string & { ～ }` みたいになってるのは branded types と呼ばれる通常の `string` と区別するための手法なんですが、過剰な気もする……？のでなくしてもいいです。

関連: #18