### PR TITLE
直積グラフたちの命名変更

### DIFF
--- a/src/dfa.ts
+++ b/src/dfa.ts
@@ -38,10 +38,10 @@ export function reverseNFA(nfa: NonEpsilonNFA): UnorderedNFA {
  * 部分集合構成法を用いて NFA から DFA を構築する。
  */
 export function determinize(nfa: UnorderedNFA): DFA {
-  return new Determinizer(nfa).determinize();
+  return new DFABuilder(nfa).build();
 }
 
-class Determinizer {
+class DFABuilder {
   private newStateList: State[] = [];
   private newTransitions: Map<State, NonNullableTransition[]> = new Map();
   private newStateToOldStateSet: Map<State, Set<State>> = new Map();
@@ -49,7 +49,7 @@ class Determinizer {
 
   constructor(private nfa: UnorderedNFA) {}
 
-  determinize(): DFA {
+  build(): DFA {
     const queue: State[] = [];
     const alphabet = this.nfa.alphabet;
     const newInitialState = this.createState(this.nfa.initialStateSet);

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -16,7 +16,7 @@ export function buildDirectProductGraphs(
 export function buildDirectProductGraph(
   sccNFA: StronglyConnectedComponentNFA,
 ): DirectProductGraph {
-  return new DirectProducer(sccNFA).build();
+  return new DirectProductBuilder(sccNFA).build();
 }
 
 export function getLeftString(state: State): string {
@@ -27,7 +27,7 @@ export function getRightString(state: State): string {
   return state.id.split('_')[1];
 }
 
-class DirectProducer {
+class DirectProductBuilder {
   private newStateList: State[] = [];
   private newTransitions: Map<State, NonNullableTransition[]> = new Map();
   private newStateToOldStateSet: Map<State, [State, State]> = new Map();

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -1,21 +1,21 @@
 import { CharSet } from 'rerejs';
 import {
-  DirectProductNFA,
+  DirectProductGraph,
   State,
   NonNullableTransition,
   StronglyConnectedComponentNFA,
 } from './types';
 import { intersectCharSets } from './char';
 
-export function buildDirectProductNFAs(
+export function buildDirectProductGraphs(
   sccs: StronglyConnectedComponentNFA[],
-): DirectProductNFA[] {
-  return sccs.map((scc) => buildDirectProductNFA(scc));
+): DirectProductGraph[] {
+  return sccs.map((scc) => buildDirectProductGraph(scc));
 }
 
-export function buildDirectProductNFA(
+export function buildDirectProductGraph(
   sccNFA: StronglyConnectedComponentNFA,
-): DirectProductNFA {
+): DirectProductGraph {
   return new DirectProducer(sccNFA).build();
 }
 
@@ -34,7 +34,7 @@ class DirectProducer {
 
   constructor(private sccNFA: StronglyConnectedComponentNFA) {}
 
-  build(): DirectProductNFA {
+  build(): DirectProductGraph {
     for (const ls of this.sccNFA.stateList) {
       for (const rs of this.sccNFA.stateList) {
         this.createState(ls, rs);
@@ -63,7 +63,7 @@ class DirectProducer {
     }
 
     return {
-      type: 'DirectProductNFA',
+      type: 'DirectProductGraph',
       stateList: this.newStateList,
       transitions: this.newTransitions,
     };

--- a/src/eda.ts
+++ b/src/eda.ts
@@ -1,11 +1,11 @@
 import { getLeftString, getRightString } from './directProduct';
 import { buildStronglyConnectedComponents } from './scc';
-import { DirectProductNFA, Message } from './types';
+import { DirectProductGraph, Message } from './types';
 
 /**
  * 強連結成分を一つ一つ見ていき、EDAを持つかメッセージを返す
  */
-export function showMessageEDA(dps: DirectProductNFA[]): Message {
+export function showMessageEDA(dps: DirectProductGraph[]): Message {
   // 別の経路で同じ文字で移動して自身に戻れたらEDA
   if (dps.some((dp) => isEDA(dp))) {
     return { status: 'Vulnerable', message: 'Detected EDA.' };
@@ -14,7 +14,7 @@ export function showMessageEDA(dps: DirectProductNFA[]): Message {
   }
 }
 
-function isEDA(dp: DirectProductNFA): boolean {
+function isEDA(dp: DirectProductGraph): boolean {
   const sccs = buildStronglyConnectedComponents(dp);
   return sccs.some((scc) => {
     // Setがもとの二重辺の配列よりサイズが小さくなれば二重辺が存在

--- a/src/enfa.ts
+++ b/src/enfa.ts
@@ -6,10 +6,10 @@ import { createCharSet } from './char';
  * Thompson's construction を用いて rerejs.Pattern から ε-NFA を構築する。
  */
 export function buildEpsilonNFA(pattern: Pattern): EpsilonNFA {
-  return new Builder(pattern).build();
+  return new EpsilonNFABuilder(pattern).build();
 }
 
-class Builder {
+class EpsilonNFABuilder {
   private stateList: State[] = [];
   private transitions: Map<State, NullableTransition[]> = new Map();
   private stateId = 0;
@@ -105,14 +105,22 @@ class Builder {
         const q1 = childNFA.initialState;
         const f1 = childNFA.acceptingState;
         if (node.nonGreedy) {
-          if (!some) this.addTransition(q0, null, f0);
+          if (!some) {
+            this.addTransition(q0, null, f0);
+          }
           this.addTransition(q0, null, q1);
           this.addTransition(f1, null, f0);
-          if (!optional) this.addTransition(f1, null, q1);
+          if (!optional) {
+            this.addTransition(f1, null, q1);
+          }
         } else {
           this.addTransition(q0, null, q1);
-          if (!some) this.addTransition(q0, null, f0);
-          if (!optional) this.addTransition(f1, null, q1);
+          if (!some) {
+            this.addTransition(q0, null, f0);
+          }
+          if (!optional) {
+            this.addTransition(f1, null, q1);
+          }
           this.addTransition(f1, null, f0);
         }
         return {

--- a/src/ida.ts
+++ b/src/ida.ts
@@ -1,7 +1,7 @@
 import { buildStronglyConnectedComponents } from './scc';
-import { TripleDirectProductNFA, Message } from './types';
+import { TripleDirectProductGraph, Message } from './types';
 
-export function showMessageIDA(tdps: TripleDirectProductNFA[]): Message {
+export function showMessageIDA(tdps: TripleDirectProductGraph[]): Message {
   if (tdps.some((tdp) => isIDA(tdp))) {
     return { status: 'Vulnerable', message: 'Detected IDA.' };
   } else {
@@ -9,7 +9,7 @@ export function showMessageIDA(tdps: TripleDirectProductNFA[]): Message {
   }
 }
 
-function isIDA(tdp: TripleDirectProductNFA): boolean {
+function isIDA(tdp: TripleDirectProductGraph): boolean {
   const sccs = buildStronglyConnectedComponents(tdp);
   return sccs.some((scc) => {
     // 追加辺 (q1, q2, q2) => (q1, q1, q2) に対応する辺 (q1, q1, q2) => (q1, q2, q2) が強連結成分内の辺として存在するかどうかを判定

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Parser } from 'rerejs';
-import { buildDirectProductNFAs } from './directProduct';
+import { buildDirectProductGraphs } from './directProduct';
 import { showMessageEDA } from './eda';
 import { buildEpsilonNFA, eliminateEpsilonTransitions } from './lib';
 import { buildStronglyConnectedComponents } from './scc';
@@ -11,7 +11,7 @@ export function detectEDA(src: string, flags?: string): Message {
     const enfa = buildEpsilonNFA(pat);
     const nfa = eliminateEpsilonTransitions(enfa);
     const sccs = buildStronglyConnectedComponents(nfa);
-    const dps = buildDirectProductNFAs(sccs);
+    const dps = buildDirectProductGraphs(sccs);
     return showMessageEDA(dps);
   } catch (e) {
     if (e instanceof Error) {

--- a/src/nfa.ts
+++ b/src/nfa.ts
@@ -10,7 +10,7 @@ import {
  * ε-NFA から ε-遷移を除去する。
  */
 export function eliminateEpsilonTransitions(nfa: EpsilonNFA): NonEpsilonNFA {
-  return new Eliminator(nfa).eliminate();
+  return new EpsilonEliminatedNFABuilder(nfa).build();
 }
 
 type ClosureItem =
@@ -23,13 +23,13 @@ type ClosureItem =
       destination: State;
     };
 
-class Eliminator {
+class EpsilonEliminatedNFABuilder {
   private newStateList: State[] = [];
   private newTransitions: Map<State, NonNullableTransition[]> = new Map();
 
   constructor(private nfa: EpsilonNFA) {}
 
-  eliminate(): NonEpsilonNFA {
+  build(): NonEpsilonNFA {
     const queue = [];
     const newInitialState = this.nfa.initialState;
     const newAcceptingStateSet = new Set<State>();

--- a/src/test.ts
+++ b/src/test.ts
@@ -3,13 +3,10 @@ import { buildEpsilonNFA } from './enfa';
 import { eliminateEpsilonTransitions } from './nfa';
 import { reverseNFA, determinize } from './dfa';
 import { toDOT } from './viz';
-import { buildDirectProductNFAs } from './directProduct';
+import { buildDirectProductGraphs } from './directProduct';
 import { buildStronglyConnectedComponents } from './scc';
 import { showMessageEDA } from './eda';
-import {
-  buildTripleDirectProductNFA,
-  buildTripleDirectProductNFAs,
-} from './tripleDirectProduct';
+import { buildTripleDirectProductGraphs } from './tripleDirectProduct';
 import { showMessageIDA } from './ida';
 
 function main() {
@@ -44,13 +41,13 @@ function main() {
     console.log(`//`, src, `strongly connected components`);
     const sccs = buildStronglyConnectedComponents(nfa);
     console.log(`//`, src, `direct product`);
-    const dps = buildDirectProductNFAs(sccs);
+    const dps = buildDirectProductGraphs(sccs);
     for (const dp of dps) {
       console.log(toDOT(dp));
     }
     console.log(`//`, src, `has EDA?: `, showMessageEDA(dps));
     console.log('//', src, `triple direct product`);
-    const tdps = buildTripleDirectProductNFAs(sccs, nfa);
+    const tdps = buildTripleDirectProductGraphs(sccs, nfa);
     console.log(`//`, src, `has IDA?: `, showMessageIDA(tdps));
     console.log(`//`, src, `reversed`);
     const rnfa = reverseNFA(nfa);

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -26,10 +26,10 @@ export function buildTripleDirectProductGraph(
   sccNFA2: StronglyConnectedComponentNFA,
   nfa: SCCPossibleAutomaton,
 ): TripleDirectProductGraph {
-  return new TripleDirectProducer(sccNFA1, sccNFA2, nfa).build();
+  return new TripleDirectProductBuilder(sccNFA1, sccNFA2, nfa).build();
 }
 
-class TripleDirectProducer {
+class TripleDirectProductBuilder {
   private newStateList: State[] = [];
   private newTransitions: Map<State, NonNullableTransition[]> = new Map();
   private newStateToOldStateSet: Map<State, [State, State, State]> = new Map();

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -1,31 +1,31 @@
 import { CharSet } from 'rerejs';
 import { intersectCharSets } from './char';
 import {
-  TripleDirectProductNFA,
+  TripleDirectProductGraph,
   SCCPossibleAutomaton,
   State,
   NonNullableTransition,
   StronglyConnectedComponentNFA,
 } from './types';
 
-export function buildTripleDirectProductNFAs(
+export function buildTripleDirectProductGraphs(
   sccs: StronglyConnectedComponentNFA[],
   nfa: SCCPossibleAutomaton,
-): TripleDirectProductNFA[] {
+): TripleDirectProductGraph[] {
   return sccs
     .map((scc1, _, sccs) =>
       sccs
         .filter((scc2) => scc1 !== scc2)
-        .map((scc2) => buildTripleDirectProductNFA(scc1, scc2, nfa)),
+        .map((scc2) => buildTripleDirectProductGraph(scc1, scc2, nfa)),
     )
     .flat(1);
 }
 
-export function buildTripleDirectProductNFA(
+export function buildTripleDirectProductGraph(
   sccNFA1: StronglyConnectedComponentNFA,
   sccNFA2: StronglyConnectedComponentNFA,
   nfa: SCCPossibleAutomaton,
-): TripleDirectProductNFA {
+): TripleDirectProductGraph {
   return new TripleDirectProducer(sccNFA1, sccNFA2, nfa).build();
 }
 
@@ -41,7 +41,7 @@ class TripleDirectProducer {
     private nfa: SCCPossibleAutomaton,
   ) {}
 
-  build(): TripleDirectProductNFA {
+  build(): TripleDirectProductGraph {
     // 強連結成分scc1, scc2間のTransitionsを取得する
     const betweenTransitionsSCC: Map<
       State,
@@ -193,7 +193,7 @@ class TripleDirectProducer {
     }
 
     return {
-      type: 'TripleDirectProductNFA',
+      type: 'TripleDirectProductGraph',
       stateList: this.newStateList,
       transitions: this.newTransitions,
       extraTransitions: this.extraTransitions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,13 +6,13 @@ export type Automaton =
   | UnorderedNFA
   | DFA
   | StronglyConnectedComponentNFA
-  | DirectProductNFA
-  | TripleDirectProductNFA;
+  | DirectProductGraph
+  | TripleDirectProductGraph;
 
 export type SCCPossibleAutomaton =
   | NonEpsilonNFA
-  | DirectProductNFA
-  | TripleDirectProductNFA;
+  | DirectProductGraph
+  | TripleDirectProductGraph;
 
 export type EpsilonNFA = {
   type: 'EpsilonNFA';
@@ -38,14 +38,14 @@ export type StronglyConnectedComponentNFA = {
   transitions: Map<State, NonNullableTransition[]>;
 };
 
-export type DirectProductNFA = {
-  type: 'DirectProductNFA';
+export type DirectProductGraph = {
+  type: 'DirectProductGraph';
   stateList: State[];
   transitions: Map<State, NonNullableTransition[]>;
 };
 
-export type TripleDirectProductNFA = {
-  type: 'TripleDirectProductNFA';
+export type TripleDirectProductGraph = {
+  type: 'TripleDirectProductGraph';
   stateList: State[];
   transitions: Map<State, NonNullableTransition[]>;
   extraTransitions: Map<State, NonNullableTransition[]>;

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -27,7 +27,7 @@ export function toDOT(
         return false;
       case 'StronglyConnectedComponentNFA':
         return false;
-      case 'DirectProductNFA':
+      case 'DirectProductGraph':
         return false;
       case 'DFA':
         return false;
@@ -53,8 +53,8 @@ export function toDOT(
 
   switch (automaton.type) {
     case 'StronglyConnectedComponentNFA':
-    case 'DirectProductNFA':
-    case 'TripleDirectProductNFA':
+    case 'DirectProductGraph':
+    case 'TripleDirectProductGraph':
       break;
     default: {
       const acceptingStateSet =


### PR DESCRIPTION
これVSCodeのrename symbolだけじゃなくて、typeをgrepして書き換えないと行けないという罠があった...
一応DirectProductNFAという文字列は最早一つもないはず、動作確認済

#18 