### PR TITLE
[WIP]遷移関数と文字の定義の変更 (#18)

### DIFF
--- a/src/automaton.ts
+++ b/src/automaton.ts
@@ -1,0 +1,48 @@
+import { State, Char } from './types';
+
+/** 遷移関数を扱うためのクラス。 */
+export class TransitionMap {
+  private stateList: State[];
+  private alphabet: Set<Char>;
+  private map: Map<State, Map<Char, State[]>>;
+
+  constructor(stateList: State[], alphabet: Set<Char>) {
+    this.stateList = stateList;
+    this.alphabet = alphabet;
+    this.map = new Map(
+      stateList.map((q) => [
+        q,
+        new Map(Array.from(alphabet).map((ch) => [ch, []])),
+      ]),
+    );
+  }
+
+  get(source: State, char: Char): State[] {
+    return this.map.get(source)!.get(char)!;
+  }
+
+  add(source: State, char: Char, destination: State): void {
+    this.get(source, char).push(destination);
+  }
+
+  *[Symbol.iterator](): Iterator<
+    [source: State, char: Char, destination: State]
+  > {
+    for (const source of this.stateList) {
+      for (const char of this.alphabet) {
+        for (const destination of this.get(source, char)) {
+          yield [source, char, destination];
+        }
+      }
+    }
+  }
+
+  /** 非破壊的にリバースした遷移を得る。 */
+  reverse(): TransitionMap {
+    const reversed = new TransitionMap(this.stateList, this.alphabet);
+    for (const [source, char, destination] of this) {
+      reversed.add(destination, char, source);
+    }
+    return reversed;
+  }
+}

--- a/src/char.ts
+++ b/src/char.ts
@@ -30,7 +30,11 @@ export function extendAlphabet(
 ): void {
   switch (node.type) {
     case 'Char': {
-      alphabet.add(node.raw);
+      let char = node.raw;
+      if (flagSet.ignoreCase) {
+        char = canonicalizeChar(char);
+      }
+      alphabet.add(char);
       return;
     }
     case 'EscapeClass': {
@@ -79,7 +83,7 @@ export function extendAlphabet(
             for (let c = begin; c < end; c++) {
               let s = String.fromCharCode(c);
               if (flagSet.ignoreCase) {
-                s = s.toUpperCase();
+                s = canonicalizeChar(s);
               }
               alphabet.add(s);
             }
@@ -109,7 +113,11 @@ export function getChars(
 ): Set<Char> {
   switch (node.type) {
     case 'Char': {
-      return new Set([node.raw]);
+      let char = node.raw;
+      if (flagSet.ignoreCase) {
+        char = canonicalizeChar(char);
+      }
+      return new Set([char]);
     }
     case 'EscapeClass': {
       switch (node.kind) {
@@ -159,7 +167,7 @@ export function getChars(
             for (let c = begin; c < end; c++) {
               let s = String.fromCharCode(c);
               if (flagSet.ignoreCase) {
-                s = s.toUpperCase();
+                s = canonicalizeChar(s);
               }
               chars.add(s);
             }
@@ -177,6 +185,10 @@ export function getChars(
       return new Set(alphabet);
     }
   }
+}
+
+export function canonicalizeChar(char: string): string {
+  return char.toUpperCase();
 }
 
 /* 以下旧実装 */

--- a/src/char.ts
+++ b/src/char.ts
@@ -1,5 +1,185 @@
 import { CharSet, FlagSet } from 'rerejs';
-import { Atom } from './types';
+import { Atom, Char } from './types';
+import { subtract } from './util';
+
+const DIGIT = new Set<Char>();
+const WORD = new Set<Char>();
+const SPACE = new Set<Char>();
+
+// \x00 から \xff までの範囲で対応
+for (let c = 0x00; c <= 0xff; c++) {
+  const s = String.fromCharCode(c);
+  if (/^\d$/.test(s)) {
+    DIGIT.add(s);
+  }
+  if (/^\w$/.test(s)) {
+    WORD.add(s);
+  }
+  if (/^\s$/.test(s)) {
+    SPACE.add(s);
+  }
+}
+
+/**
+ * オートマトン構築時に出現する文字を集める。
+ */
+export function extendAlphabet(
+  alphabet: Set<Char>,
+  node: Atom,
+  flagSet: FlagSet,
+): void {
+  switch (node.type) {
+    case 'Char': {
+      alphabet.add(node.raw);
+      return;
+    }
+    case 'EscapeClass': {
+      switch (node.kind) {
+        case 'digit': {
+          for (const ch of DIGIT) {
+            alphabet.add(ch);
+          }
+          break;
+        }
+        case 'word': {
+          for (const ch of WORD) {
+            alphabet.add(ch);
+          }
+          break;
+        }
+        case 'space': {
+          for (const ch of SPACE) {
+            alphabet.add(ch);
+          }
+          break;
+        }
+        case 'unicode_property': {
+          throw new Error('unimplemented');
+        }
+        case 'unicode_property_value': {
+          throw new Error('unimplemented');
+        }
+      }
+      if (node.invert) {
+        alphabet.add(null);
+      }
+      return;
+    }
+    case 'Class': {
+      for (const child of node.children) {
+        switch (child.type) {
+          case 'Char':
+          case 'EscapeClass': {
+            extendAlphabet(alphabet, child, flagSet);
+            break;
+          }
+          case 'ClassRange': {
+            const begin = child.children[0].value;
+            const end = child.children[1].value + 1;
+            for (let c = begin; c < end; c++) {
+              let s = String.fromCharCode(c);
+              if (flagSet.ignoreCase) {
+                s = s.toUpperCase();
+              }
+              alphabet.add(s);
+            }
+            break;
+          }
+        }
+      }
+      if (node.invert) {
+        alphabet.add(null);
+      }
+      return;
+    }
+    case 'Dot': {
+      alphabet.add(null);
+      return;
+    }
+  }
+}
+
+/**
+ * 構築済みの alphabet から対象となる文字を集める。
+ */
+export function getChars(
+  alphabet: Set<Char>,
+  node: Atom,
+  flagSet: FlagSet,
+): Set<Char> {
+  switch (node.type) {
+    case 'Char': {
+      return new Set([node.raw]);
+    }
+    case 'EscapeClass': {
+      switch (node.kind) {
+        case 'digit': {
+          if (!node.invert) {
+            return new Set(DIGIT);
+          } else {
+            return subtract(alphabet, DIGIT);
+          }
+        }
+        case 'word': {
+          if (!node.invert) {
+            return new Set(WORD);
+          } else {
+            return subtract(alphabet, WORD);
+          }
+        }
+        case 'space': {
+          if (!node.invert) {
+            return new Set(SPACE);
+          } else {
+            return subtract(alphabet, SPACE);
+          }
+        }
+        case 'unicode_property': {
+          throw new Error('unimplemented');
+        }
+        case 'unicode_property_value': {
+          throw new Error('unimplemented');
+        }
+      }
+    }
+    case 'Class': {
+      const chars = new Set<Char>();
+      for (const child of node.children) {
+        switch (child.type) {
+          case 'Char':
+          case 'EscapeClass': {
+            for (const ch of getChars(alphabet, child, flagSet)) {
+              chars.add(ch);
+            }
+            break;
+          }
+          case 'ClassRange': {
+            const begin = child.children[0].value;
+            const end = child.children[1].value + 1;
+            for (let c = begin; c < end; c++) {
+              let s = String.fromCharCode(c);
+              if (flagSet.ignoreCase) {
+                s = s.toUpperCase();
+              }
+              chars.add(s);
+            }
+            break;
+          }
+        }
+      }
+      if (!node.invert) {
+        return chars;
+      } else {
+        return subtract(alphabet, chars);
+      }
+    }
+    case 'Dot': {
+      return new Set(alphabet);
+    }
+  }
+}
+
+/* 以下旧実装 */
 
 export const MAX_CODE_POINT = 0x110000;
 

--- a/src/dfa.ts
+++ b/src/dfa.ts
@@ -63,8 +63,8 @@ class DFABuilder {
     }
     return {
       type: 'DFA',
-      alphabet,
       stateList: this.newStateList,
+      alphabet,
       initialState: newInitialState,
       acceptingStateSet: newAcceptingStateSet,
       transitions: this.newTransitions,

--- a/src/dfa.ts
+++ b/src/dfa.ts
@@ -25,13 +25,11 @@ export function determinize(nfa: UnorderedNFA): DFA {
 
 class DFABuilder {
   private newStateList: State[] = [];
-  private newTransitions: TransitionMap;
+  private newTransitions = new TransitionMap();
   private newStateToOldStateSet: Map<State, Set<State>> = new Map();
   private newStateId = 0;
 
-  constructor(private nfa: UnorderedNFA) {
-    this.newTransitions = new TransitionMap(nfa.stateList, nfa.alphabet);
-  }
+  constructor(private nfa: UnorderedNFA) {}
 
   build(): DFA {
     const queue: State[] = [];

--- a/src/dfa.ts
+++ b/src/dfa.ts
@@ -1,36 +1,18 @@
-import { CharSet } from 'rerejs';
-import {
-  NonEpsilonNFA,
-  UnorderedNFA,
-  DFA,
-  State,
-  NonNullableTransition,
-} from './types';
+import { NonEpsilonNFA, UnorderedNFA, DFA, State } from './types';
+import { TransitionMap } from './automaton';
 import { equals, intersect } from './util';
 
 /**
  * NFA をリバースする。優先度の情報は失われる。
  */
 export function reverseNFA(nfa: NonEpsilonNFA): UnorderedNFA {
-  const reversedTransitions = new Map<State, NonNullableTransition[]>();
-  for (const q of nfa.stateList) {
-    reversedTransitions.set(q, []);
-  }
-  for (const [q, ds] of nfa.transitions) {
-    for (const d of ds) {
-      reversedTransitions.get(d.destination)!.push({
-        charSet: d.charSet,
-        destination: q,
-      });
-    }
-  }
   return {
     type: 'UnorderedNFA',
     alphabet: nfa.alphabet,
     stateList: nfa.stateList,
     initialStateSet: nfa.acceptingStateSet,
     acceptingStateSet: new Set([nfa.initialState]),
-    transitions: reversedTransitions,
+    transitions: nfa.transitions.reverse(),
   };
 }
 
@@ -43,11 +25,13 @@ export function determinize(nfa: UnorderedNFA): DFA {
 
 class DFABuilder {
   private newStateList: State[] = [];
-  private newTransitions: Map<State, NonNullableTransition[]> = new Map();
+  private newTransitions: TransitionMap;
   private newStateToOldStateSet: Map<State, Set<State>> = new Map();
   private newStateId = 0;
 
-  constructor(private nfa: UnorderedNFA) {}
+  constructor(private nfa: UnorderedNFA) {
+    this.newTransitions = new TransitionMap(nfa.stateList, nfa.alphabet);
+  }
 
   build(): DFA {
     const queue: State[] = [];
@@ -61,15 +45,9 @@ class DFABuilder {
       if (intersect(qs0, this.nfa.acceptingStateSet).size !== 0) {
         newAcceptingStateSet.add(q0);
       }
-      for (let i = 0; i < alphabet.length - 1; i++) {
-        const codePointRange: [number, number] = [alphabet[i], alphabet[i + 1]];
+      for (const char of alphabet) {
         const qs1 = new Set(
-          Array.from(qs0).flatMap((q) =>
-            this.nfa.transitions
-              .get(q)!
-              .filter((d) => d.charSet.has(codePointRange[0]))
-              .map((d) => d.destination),
-          ),
+          Array.from(qs0).flatMap((q) => this.nfa.transitions.get(q, char)),
         );
 
         if (qs1.size === 0) {
@@ -80,12 +58,12 @@ class DFABuilder {
           q1 = this.createState(qs1);
           queue.push(q1);
         }
-        this.addTransition(q0, codePointRange, q1);
+        this.newTransitions.add(q0, char, q1);
       }
     }
     return {
       type: 'DFA',
-      alphabet: this.nfa.alphabet,
+      alphabet,
       stateList: this.newStateList,
       initialState: newInitialState,
       acceptingStateSet: newAcceptingStateSet,
@@ -105,23 +83,8 @@ class DFABuilder {
   createState(oldStateSet: Set<State>): State {
     const state = `Q${this.newStateId++}` as State;
     this.newStateList.push(state);
-    this.newTransitions.set(state, []);
+
     this.newStateToOldStateSet.set(state, oldStateSet);
     return state;
-  }
-
-  addTransition(
-    source: State,
-    codePointRange: [number, number],
-    destination: State,
-  ): void {
-    for (const d of this.newTransitions.get(source)!) {
-      if (d.destination === destination) {
-        d.charSet.add(codePointRange[0], codePointRange[1]);
-        return;
-      }
-    }
-    const charSet = new CharSet(codePointRange);
-    this.newTransitions.get(source)!.push({ charSet, destination });
   }
 }

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -1,20 +1,20 @@
 import {
   DirectProductGraph,
   State,
-  StronglyConnectedComponentNFA,
+  StronglyConnectedComponentGraph,
 } from './types';
 import { TransitionMap } from './automaton';
 
 export function buildDirectProductGraphs(
-  sccs: StronglyConnectedComponentNFA[],
+  sccs: StronglyConnectedComponentGraph[],
 ): DirectProductGraph[] {
   return sccs.map((scc) => buildDirectProductGraph(scc));
 }
 
 export function buildDirectProductGraph(
-  sccNFA: StronglyConnectedComponentNFA,
+  sccGraph: StronglyConnectedComponentGraph,
 ): DirectProductGraph {
-  return new DirectProductBuilder(sccNFA).build();
+  return new DirectProductBuilder(sccGraph).build();
 }
 
 export function getLeftState(state: State): State {
@@ -30,20 +30,20 @@ class DirectProductBuilder {
   private newTransitions = new TransitionMap();
   private newStateToOldStateSet: Map<State, [State, State]> = new Map();
 
-  constructor(private sccNFA: StronglyConnectedComponentNFA) {}
+  constructor(private sccGraph: StronglyConnectedComponentGraph) {}
 
   build(): DirectProductGraph {
-    for (const ls of this.sccNFA.stateList) {
-      for (const rs of this.sccNFA.stateList) {
+    for (const ls of this.sccGraph.stateList) {
+      for (const rs of this.sccGraph.stateList) {
         this.createState(ls, rs);
       }
     }
 
-    for (const lq of this.sccNFA.stateList) {
-      for (const rq of this.sccNFA.stateList) {
-        for (const char of this.sccNFA.alphabet) {
-          for (const ld of this.sccNFA.transitions.get(lq, char)) {
-            for (const rd of this.sccNFA.transitions.get(rq, char)!) {
+    for (const lq of this.sccGraph.stateList) {
+      for (const rq of this.sccGraph.stateList) {
+        for (const char of this.sccGraph.alphabet) {
+          for (const ld of this.sccGraph.transitions.get(lq, char)) {
+            for (const rd of this.sccGraph.transitions.get(rq, char)!) {
               let source = this.getState(lq, rq);
               if (source === null) {
                 source = this.createState(lq, rq);
@@ -65,7 +65,7 @@ class DirectProductBuilder {
     return {
       type: 'DirectProductGraph',
       stateList: this.newStateList,
-      alphabet: this.sccNFA.alphabet,
+      alphabet: this.sccGraph.alphabet,
       transitions: this.newTransitions,
     };
   }

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -43,7 +43,7 @@ class DirectProductBuilder {
       for (const rq of this.sccGraph.stateList) {
         for (const char of this.sccGraph.alphabet) {
           for (const ld of this.sccGraph.transitions.get(lq, char)) {
-            for (const rd of this.sccGraph.transitions.get(rq, char)!) {
+            for (const rd of this.sccGraph.transitions.get(rq, char)) {
               let source = this.getState(lq, rq);
               if (source === null) {
                 source = this.createState(lq, rq);

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -27,12 +27,10 @@ export function getRightState(state: State): State {
 
 class DirectProductBuilder {
   private newStateList: State[] = [];
-  private newTransitions: TransitionMap;
+  private newTransitions = new TransitionMap();
   private newStateToOldStateSet: Map<State, [State, State]> = new Map();
 
-  constructor(private sccNFA: StronglyConnectedComponentNFA) {
-    this.newTransitions = new TransitionMap(sccNFA.stateList, sccNFA.alphabet);
-  }
+  constructor(private sccNFA: StronglyConnectedComponentNFA) {}
 
   build(): DirectProductGraph {
     for (const ls of this.sccNFA.stateList) {

--- a/src/eda.ts
+++ b/src/eda.ts
@@ -19,18 +19,13 @@ function isEDA(dp: DirectProductGraph): boolean {
   return sccs.some((scc) => {
     // Setがもとの二重辺の配列よりサイズが小さくなれば二重辺が存在
     for (const source of scc.stateList) {
-      const loopBackStringArray = scc.transitions
-        .get(source)!
-        .filter((tr) => {
-          return source === tr.destination;
-        })
-        .map((tr) => {
-          return tr.charSet.toString();
-        });
-      const loopBackStringSet = new Set(loopBackStringArray);
+      for (const char of scc.alphabet) {
+        const destinationArray = scc.transitions.get(source, char);
+        const destinationSet = new Set(destinationArray);
 
-      if (loopBackStringSet.size < loopBackStringArray.length) {
-        return true;
+        if (destinationSet.size < destinationArray.length) {
+          return true;
+        }
       }
     }
 

--- a/src/eda.ts
+++ b/src/eda.ts
@@ -17,13 +17,14 @@ export function showMessageEDA(dps: DirectProductGraph[]): Message {
 function isEDA(dp: DirectProductGraph): boolean {
   const sccs = buildStronglyConnectedComponents(dp);
   return sccs.some((scc) => {
-    // Setがもとの二重辺の配列よりサイズが小さくなれば二重辺が存在
+    // 遷移元と遷移先が同じ遷移が複数存在するかを検出
     for (const source of scc.stateList) {
       for (const char of scc.alphabet) {
-        const destinationArray = scc.transitions.get(source, char);
-        const destinationSet = new Set(destinationArray);
+        const destinationArray = scc.transitions
+          .get(source, char)
+          .filter((d) => d === source);
 
-        if (destinationSet.size < destinationArray.length) {
+        if (destinationArray.length >= 2) {
           return true;
         }
       }

--- a/src/enfa.ts
+++ b/src/enfa.ts
@@ -33,15 +33,12 @@ class EpsilonNFABuilder {
       if (node === null) {
         transitions.get(source)!.push({ epsilon: true, destination });
       } else {
-        for (const char of getChars(
-          this.alphabet,
-          node,
-          this.pattern.flagSet,
-        )) {
+        for (const char of this.getChars(node)) {
           transitions.get(source)!.push({ epsilon: false, char, destination });
         }
       }
     }
+
     return {
       type: 'EpsilonNFA',
       alphabet: this.alphabet,
@@ -156,7 +153,7 @@ class EpsilonNFABuilder {
       case 'Dot': {
         const q0 = this.createState();
         const f0 = this.createState();
-        extendAlphabet(this.alphabet, node, this.pattern.flagSet);
+        this.extendAlphabet(node);
         this.addTransition(q0, node, f0);
         return {
           initialState: q0,
@@ -174,6 +171,15 @@ class EpsilonNFABuilder {
     const state = `q${this.stateId++}` as State;
     this.stateList.push(state);
     return state;
+  }
+
+  private extendAlphabet(node: Atom): void {
+    // NOTE: 計算量が一番少ないthis.alphabetの更新方法
+    extendAlphabet(this.alphabet, node, this.pattern.flagSet);
+  }
+
+  private getChars(node: Atom): Set<Char> {
+    return getChars(this.alphabet, node, this.pattern.flagSet);
   }
 
   private addTransition(

--- a/src/ida.ts
+++ b/src/ida.ts
@@ -14,11 +14,9 @@ function isIDA(tdp: TripleDirectProductGraph): boolean {
   return sccs.some((scc) => {
     // 追加辺 (q1, q2, q2) => (q1, q1, q2) に対応する辺 (q1, q1, q2) => (q1, q2, q2) が強連結成分内の辺として存在するかどうかを判定
 
-    for (const [q, ts] of tdp.extraTransitions) {
-      for (const t of ts) {
-        return scc.transitions
-          .get(t.destination)
-          ?.some((scc_dest) => scc_dest.destination === q);
+    for (const [q, char, d] of tdp.extraTransitions) {
+      if (scc.transitions.get(d, char).includes(q)) {
+        return true;
       }
     }
     return false;

--- a/src/nfa.ts
+++ b/src/nfa.ts
@@ -20,11 +20,9 @@ type ClosureItem =
 
 class EpsilonEliminatedNFABuilder {
   private newStateList: State[] = [];
-  private newTransitions: TransitionMap;
+  private newTransitions = new TransitionMap();
 
-  constructor(private nfa: EpsilonNFA) {
-    this.newTransitions = new TransitionMap(nfa.stateList, nfa.alphabet);
-  }
+  constructor(private nfa: EpsilonNFA) {}
 
   build(): NonEpsilonNFA {
     const queue = [];

--- a/src/nfa.ts
+++ b/src/nfa.ts
@@ -50,8 +50,8 @@ class EpsilonEliminatedNFABuilder {
     }
     return {
       type: 'NonEpsilonNFA',
-      alphabet: this.nfa.alphabet,
       stateList: this.newStateList,
+      alphabet: this.nfa.alphabet,
       initialState: newInitialState,
       acceptingStateSet: newAcceptingStateSet,
       transitions: this.newTransitions,

--- a/src/nfa.ts
+++ b/src/nfa.ts
@@ -1,10 +1,5 @@
-import { CharSet } from 'rerejs';
-import {
-  EpsilonNFA,
-  NonEpsilonNFA,
-  State,
-  NonNullableTransition,
-} from './types';
+import { EpsilonNFA, NonEpsilonNFA, State, Char } from './types';
+import { TransitionMap } from './automaton';
 
 /**
  * ε-NFA から ε-遷移を除去する。
@@ -19,33 +14,35 @@ type ClosureItem =
     }
   | {
       accepting: false;
-      charSet: CharSet;
+      char: Char;
       destination: State;
     };
 
 class EpsilonEliminatedNFABuilder {
   private newStateList: State[] = [];
-  private newTransitions: Map<State, NonNullableTransition[]> = new Map();
+  private newTransitions: TransitionMap;
 
-  constructor(private nfa: EpsilonNFA) {}
+  constructor(private nfa: EpsilonNFA) {
+    this.newTransitions = new TransitionMap(nfa.stateList, nfa.alphabet);
+  }
 
   build(): NonEpsilonNFA {
     const queue = [];
     const newInitialState = this.nfa.initialState;
     const newAcceptingStateSet = new Set<State>();
-    this.addState(newInitialState);
+    this.newStateList.push(newInitialState);
     queue.push(newInitialState);
     while (queue.length !== 0) {
       const q0 = queue.shift()!;
-      const c = this.buildClosure(q0);
-      for (const ci of c) {
-        if (ci.accepting) {
+      const closure = this.buildClosure(q0);
+      for (const item of closure) {
+        if (item.accepting) {
           newAcceptingStateSet.add(q0);
         } else {
-          const q1 = ci.destination;
-          this.addTransition(q0, ci.charSet, q1);
+          const q1 = item.destination;
+          this.newTransitions.add(q0, item.char, q1);
           if (!this.newStateList.includes(q1)) {
-            this.addState(q1);
+            this.newStateList.push(q1);
             queue.push(q1);
           }
         }
@@ -72,31 +69,18 @@ class EpsilonEliminatedNFABuilder {
       return [{ accepting: true }];
     } else {
       return this.nfa.transitions.get(q)!.flatMap((d) => {
-        if (d.charSet === null) {
+        if (d.epsilon) {
           return this.buildClosure(d.destination, [...path, q]);
         } else {
           return [
             {
               accepting: false,
-              charSet: d.charSet,
+              char: d.char,
               destination: d.destination,
             },
           ];
         }
       });
     }
-  }
-
-  private addState(oldState: State): void {
-    this.newStateList.push(oldState);
-    this.newTransitions.set(oldState, []);
-  }
-
-  private addTransition(
-    source: State,
-    charSet: CharSet,
-    destination: State,
-  ): void {
-    this.newTransitions.get(source)!.push({ charSet, destination });
   }
 }

--- a/src/scc.ts
+++ b/src/scc.ts
@@ -1,13 +1,13 @@
 import {
   SCCPossibleAutomaton,
   State,
-  StronglyConnectedComponentNFA,
+  StronglyConnectedComponentGraph,
 } from './types';
 import { TransitionMap } from './automaton';
 
 export function buildStronglyConnectedComponents(
   nfa: SCCPossibleAutomaton,
-): StronglyConnectedComponentNFA[] {
+): StronglyConnectedComponentGraph[] {
   return new StronglyConnectedComponents(nfa).build();
 }
 
@@ -16,11 +16,11 @@ class StronglyConnectedComponents {
   private used: Map<State, boolean> = new Map();
   private order: State[] = [];
   private comp: Map<State, number> = new Map();
-  private sccList: StronglyConnectedComponentNFA[] = [];
+  private sccList: StronglyConnectedComponentGraph[] = [];
 
   constructor(private nfa: SCCPossibleAutomaton) {}
 
-  build(): StronglyConnectedComponentNFA[] {
+  build(): StronglyConnectedComponentGraph[] {
     this.nfa.stateList.forEach((state) => {
       this.used.set(state, false);
       this.comp.set(state, -1);
@@ -79,7 +79,7 @@ class StronglyConnectedComponents {
 
     if (cnt === this.sccList.length) {
       this.sccList.push({
-        type: 'StronglyConnectedComponentNFA',
+        type: 'StronglyConnectedComponentGraph',
         stateList: [],
         alphabet: this.nfa.alphabet,
         transitions: new TransitionMap(),

--- a/src/scc.ts
+++ b/src/scc.ts
@@ -1,9 +1,9 @@
 import {
-  NonNullableTransition,
   SCCPossibleAutomaton,
   State,
   StronglyConnectedComponentNFA,
 } from './types';
+import { TransitionMap } from './automaton';
 
 export function buildStronglyConnectedComponents(
   nfa: SCCPossibleAutomaton,
@@ -12,7 +12,7 @@ export function buildStronglyConnectedComponents(
 }
 
 class StronglyConnectedComponents {
-  private reverseTransitions: Map<State, NonNullableTransition[]> = new Map();
+  private reversedTransitions = new TransitionMap();
   private used: Map<State, boolean> = new Map();
   private order: State[] = [];
   private comp: Map<State, number> = new Map();
@@ -24,16 +24,9 @@ class StronglyConnectedComponents {
     this.nfa.stateList.forEach((state) => {
       this.used.set(state, false);
       this.comp.set(state, -1);
-      this.reverseTransitions.set(state, []);
     });
 
-    for (const [q, ds] of this.nfa.transitions) {
-      for (const d of ds) {
-        this.reverseTransitions
-          .get(d.destination)!
-          .push({ charSet: d.charSet, destination: q });
-      }
-    }
+    this.reversedTransitions = this.nfa.transitions.reverse();
 
     for (const state of this.nfa.stateList) {
       this.dfs(state);
@@ -51,9 +44,11 @@ class StronglyConnectedComponents {
 
     for (const sccNFA of this.sccList) {
       for (const state of sccNFA.stateList) {
-        for (const tr of this.nfa.transitions.get(state)!) {
-          if (this.comp.get(state) === this.comp.get(tr.destination)) {
-            sccNFA.transitions.get(state)!.push(tr);
+        for (const char of this.nfa.alphabet) {
+          for (const destination of this.nfa.transitions.get(state, char)) {
+            if (this.comp.get(state) === this.comp.get(destination)) {
+              sccNFA.transitions.add(state, char, destination);
+            }
           }
         }
       }
@@ -63,16 +58,22 @@ class StronglyConnectedComponents {
   }
 
   private dfs(state: State): void {
-    if (this.used.get(state)!) return;
+    if (this.used.get(state)!) {
+      return;
+    }
     this.used.set(state, true);
-    for (const tr of this.nfa.transitions.get(state)!) {
-      this.dfs(tr.destination);
+    for (const char of this.nfa.alphabet) {
+      for (const destination of this.reversedTransitions.get(state, char)) {
+        this.dfs(destination);
+      }
     }
     this.order.push(state);
   }
 
   private rdfs(state: State, cnt: number): void {
-    if (this.comp.get(state)! !== -1) return;
+    if (this.comp.get(state)! !== -1) {
+      return;
+    }
 
     this.comp.set(state, cnt);
 
@@ -80,17 +81,19 @@ class StronglyConnectedComponents {
       this.sccList.push({
         type: 'StronglyConnectedComponentNFA',
         stateList: [],
-        transitions: new Map(),
+        alphabet: this.nfa.alphabet,
+        transitions: new TransitionMap(),
       });
     }
 
     const sccNFA = this.sccList[cnt];
     sccNFA.stateList.push(state);
-    sccNFA.transitions.set(state, []);
 
     // 同じ強連結成分同士の集合を作る
-    for (const rt of this.reverseTransitions.get(state)!) {
-      this.rdfs(rt.destination, cnt);
+    for (const char of this.nfa.alphabet) {
+      for (const destination of this.reversedTransitions.get(state, char)) {
+        this.rdfs(destination, cnt);
+      }
     }
   }
 }

--- a/src/scc.ts
+++ b/src/scc.ts
@@ -91,7 +91,7 @@ class StronglyConnectedComponents {
 
     // 同じ強連結成分同士の集合を作る
     for (const char of this.nfa.alphabet) {
-      for (const destination of this.reversedTransitions.get(state, char)) {
+      for (const destination of this.nfa.transitions.get(state, char)) {
         this.rdfs(destination, cnt);
       }
     }

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -44,23 +44,21 @@ class TripleDirectProductBuilder {
     const betweenTransitionsSCC = new TransitionMap();
 
     for (const s1 of this.sccNFA1.stateList) {
-      for (const s1t of this.nfa.transitions.get(s1)!) {
-        if (this.sccNFA2.stateList.includes(s1t.destination)) {
-          if (betweenTransitionsSCC.get(s1)! === undefined) {
-            betweenTransitionsSCC.set(s1, []);
+      for (const char of this.nfa.alphabet) {
+        for (const d of this.nfa.transitions.get(s1, char)) {
+          if (this.sccNFA2.stateList.includes(d)) {
+            betweenTransitionsSCC.add(s1, char, d);
           }
-          betweenTransitionsSCC.get(s1)!.push(s1t);
         }
       }
     }
 
     for (const s2 of this.sccNFA2.stateList) {
-      for (const s2t of this.sccNFA2.transitions.get(s2)!) {
-        if (this.sccNFA1.stateList.includes(s2t.destination)) {
-          if (betweenTransitionsSCC.get(s2)! === undefined) {
-            betweenTransitionsSCC.set(s2, []);
+      for (const char of this.nfa.alphabet) {
+        for (const d of this.nfa.transitions.get(s2, char)) {
+          if (this.sccNFA1.stateList.includes(d)) {
+            betweenTransitionsSCC.add(s2, char, d);
           }
-          betweenTransitionsSCC.get(s2)!.push(s2t);
         }
       }
     }

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -1,13 +1,13 @@
 import {
   TripleDirectProductGraph,
-  StronglyConnectedComponentNFA,
+  StronglyConnectedComponentGraph,
   SCCPossibleAutomaton,
   State,
 } from './types';
 import { TransitionMap } from './automaton';
 
 export function buildTripleDirectProductGraphs(
-  sccs: StronglyConnectedComponentNFA[],
+  sccs: StronglyConnectedComponentGraph[],
   nfa: SCCPossibleAutomaton,
 ): TripleDirectProductGraph[] {
   return sccs
@@ -20,11 +20,11 @@ export function buildTripleDirectProductGraphs(
 }
 
 export function buildTripleDirectProductGraph(
-  sccNFA1: StronglyConnectedComponentNFA,
-  sccNFA2: StronglyConnectedComponentNFA,
+  sccGraph1: StronglyConnectedComponentGraph,
+  sccGraph2: StronglyConnectedComponentGraph,
   nfa: SCCPossibleAutomaton,
 ): TripleDirectProductGraph {
-  return new TripleDirectProductBuilder(sccNFA1, sccNFA2, nfa).build();
+  return new TripleDirectProductBuilder(sccGraph1, sccGraph2, nfa).build();
 }
 
 class TripleDirectProductBuilder {
@@ -34,8 +34,8 @@ class TripleDirectProductBuilder {
   private extraTransitions = new TransitionMap();
 
   constructor(
-    private sccNFA1: StronglyConnectedComponentNFA,
-    private sccNFA2: StronglyConnectedComponentNFA,
+    private sccGraph1: StronglyConnectedComponentGraph,
+    private sccGraph2: StronglyConnectedComponentGraph,
     private nfa: SCCPossibleAutomaton,
   ) {}
 
@@ -43,34 +43,34 @@ class TripleDirectProductBuilder {
     // 強連結成分scc1, scc2間のTransitionsを取得する
     const betweenTransitionsSCC = new TransitionMap();
 
-    for (const s1 of this.sccNFA1.stateList) {
+    for (const s1 of this.sccGraph1.stateList) {
       for (const char of this.nfa.alphabet) {
         for (const d of this.nfa.transitions.get(s1, char)) {
-          if (this.sccNFA2.stateList.includes(d)) {
+          if (this.sccGraph2.stateList.includes(d)) {
             betweenTransitionsSCC.add(s1, char, d);
           }
         }
       }
     }
 
-    for (const s2 of this.sccNFA2.stateList) {
+    for (const s2 of this.sccGraph2.stateList) {
       for (const char of this.nfa.alphabet) {
         for (const d of this.nfa.transitions.get(s2, char)) {
-          if (this.sccNFA1.stateList.includes(d)) {
+          if (this.sccGraph1.stateList.includes(d)) {
             betweenTransitionsSCC.add(s2, char, d);
           }
         }
       }
     }
 
-    // 後々のループのネストを浅くするため、2つのsccNFAの和集合を作る
+    // 後々のループのネストを浅くするため、2つのsccGraphの和集合を作る
     const sumOfTwoSccStateList: Set<State> = new Set();
 
-    for (const s1 of this.sccNFA1.stateList) {
+    for (const s1 of this.sccGraph1.stateList) {
       sumOfTwoSccStateList.add(s1);
     }
 
-    for (const s2 of this.sccNFA2.stateList) {
+    for (const s2 of this.sccGraph2.stateList) {
       sumOfTwoSccStateList.add(s2);
     }
 
@@ -84,11 +84,11 @@ class TripleDirectProductBuilder {
 
     const sumOfTwoSccTransitions = new TransitionMap();
 
-    for (const [q, char, d] of this.sccNFA1.transitions) {
+    for (const [q, char, d] of this.sccGraph1.transitions) {
       sumOfTwoSccTransitions.add(q, char, d);
     }
 
-    for (const [q, char, d] of this.sccNFA2.transitions) {
+    for (const [q, char, d] of this.sccGraph2.transitions) {
       sumOfTwoSccTransitions.add(q, char, d);
     }
 
@@ -97,8 +97,8 @@ class TripleDirectProductBuilder {
     }
 
     const alphabet = new Set([
-      ...this.sccNFA1.alphabet,
-      ...this.sccNFA2.alphabet,
+      ...this.sccGraph1.alphabet,
+      ...this.sccGraph2.alphabet,
       ...this.nfa.alphabet,
     ]);
 

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -107,8 +107,8 @@ class TripleDirectProductBuilder {
         for (const rq of sumOfTwoSccStateList) {
           for (const char of alphabet) {
             for (const ld of sumOfTwoSccTransitions.get(lq, char)) {
-              for (const cd of sumOfTwoSccTransitions.get(lq, char)) {
-                for (const rd of sumOfTwoSccTransitions.get(lq, char)) {
+              for (const cd of sumOfTwoSccTransitions.get(cq, char)) {
+                for (const rd of sumOfTwoSccTransitions.get(rq, char)) {
                   let source = this.getState(lq, cq, rq);
                   if (source === null) {
                     source = this.createState(lq, cq, rq);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ import {
   Dot as RerejsDot,
 } from 'rerejs';
 
+import { TransitionMap } from './automaton';
+
 export type Automaton =
   | EpsilonNFA
   | NonEpsilonNFA
@@ -21,8 +23,8 @@ export type SCCPossibleAutomaton =
 
 export type EpsilonNFA = {
   type: 'EpsilonNFA';
-  alphabet: Char[];
   stateList: State[];
+  alphabet: Set<Char>;
   initialState: State;
   acceptingState: State;
   transitions: Map<State, NullableTransition[]>;
@@ -30,51 +32,51 @@ export type EpsilonNFA = {
 
 export type NonEpsilonNFA = {
   type: 'NonEpsilonNFA';
-  alphabet: Char[];
   stateList: State[];
+  alphabet: Set<Char>;
   initialState: State;
   acceptingStateSet: Set<State>;
-  transitions: Map<State, Map<Char, State[]>>;
+  transitions: TransitionMap;
 };
 
 export type StronglyConnectedComponentNFA = {
   type: 'StronglyConnectedComponentNFA';
-  alphabet: Char[];
   stateList: State[];
-  transitions: Map<State, Map<Char, State[]>>;
+  alphabet: Set<Char>;
+  transitions: TransitionMap;
 };
 
 export type DirectProductGraph = {
   type: 'DirectProductGraph';
-  alphabet: Char[];
+  alphabet: Set<Char>;
   stateList: State[];
-  transitions: Map<State, Map<Char, State[]>>;
+  transitions: TransitionMap;
 };
 
 export type TripleDirectProductGraph = {
   type: 'TripleDirectProductGraph';
-  alphabet: Char[];
   stateList: State[];
-  transitions: Map<State, Map<Char, State[]>>;
-  extraTransitions: Map<State, Map<Char, State[]>>;
+  alphabet: Set<Char>;
+  transitions: TransitionMap;
+  extraTransitions: TransitionMap;
 };
 
 export type UnorderedNFA = {
   type: 'UnorderedNFA';
-  alphabet: Char[];
   stateList: State[];
+  alphabet: Set<Char>;
   initialStateSet: Set<State>;
   acceptingStateSet: Set<State>;
-  transitions: Map<State, Map<Char, State[]>>;
+  transitions: TransitionMap;
 };
 
 export type DFA = {
   type: 'DFA';
-  alphabet: Char[];
   stateList: State[];
+  alphabet: Set<Char>;
   initialState: State;
   acceptingStateSet: Set<State>;
-  transitions: Map<State, Map<Char, State[]>>;
+  transitions: TransitionMap;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-import { Char, EscapeClass, Class, Dot, CharSet } from 'rerejs';
+import {
+  Char as RerejsChar,
+  EscapeClass as RerejsEscapeClass,
+  Class as RerejsClass,
+  Dot as RerejsDot,
+} from 'rerejs';
 
 export type Automaton =
   | EpsilonNFA
@@ -16,7 +21,7 @@ export type SCCPossibleAutomaton =
 
 export type EpsilonNFA = {
   type: 'EpsilonNFA';
-  alphabet: number[];
+  alphabet: Char[];
   stateList: State[];
   initialState: State;
   acceptingState: State;
@@ -25,48 +30,51 @@ export type EpsilonNFA = {
 
 export type NonEpsilonNFA = {
   type: 'NonEpsilonNFA';
-  alphabet: number[];
+  alphabet: Char[];
   stateList: State[];
   initialState: State;
   acceptingStateSet: Set<State>;
-  transitions: Map<State, NonNullableTransition[]>;
+  transitions: Map<State, Map<Char, State[]>>;
 };
 
 export type StronglyConnectedComponentNFA = {
   type: 'StronglyConnectedComponentNFA';
+  alphabet: Char[];
   stateList: State[];
-  transitions: Map<State, NonNullableTransition[]>;
+  transitions: Map<State, Map<Char, State[]>>;
 };
 
 export type DirectProductGraph = {
   type: 'DirectProductGraph';
+  alphabet: Char[];
   stateList: State[];
-  transitions: Map<State, NonNullableTransition[]>;
+  transitions: Map<State, Map<Char, State[]>>;
 };
 
 export type TripleDirectProductGraph = {
   type: 'TripleDirectProductGraph';
+  alphabet: Char[];
   stateList: State[];
-  transitions: Map<State, NonNullableTransition[]>;
-  extraTransitions: Map<State, NonNullableTransition[]>;
+  transitions: Map<State, Map<Char, State[]>>;
+  extraTransitions: Map<State, Map<Char, State[]>>;
 };
 
 export type UnorderedNFA = {
   type: 'UnorderedNFA';
-  alphabet: number[];
+  alphabet: Char[];
   stateList: State[];
   initialStateSet: Set<State>;
   acceptingStateSet: Set<State>;
-  transitions: Map<State, NonNullableTransition[]>;
+  transitions: Map<State, Map<Char, State[]>>;
 };
 
 export type DFA = {
   type: 'DFA';
-  alphabet: number[];
+  alphabet: Char[];
   stateList: State[];
   initialState: State;
   acceptingStateSet: Set<State>;
-  transitions: Map<State, NonNullableTransition[]>;
+  transitions: Map<State, Map<Char, State[]>>;
 };
 
 /**
@@ -78,19 +86,29 @@ export type DFA = {
  */
 export type State = string & { __stateBrand: never };
 
-export type Atom = Char | EscapeClass | Class | Dot;
+export type Atom = RerejsChar | RerejsEscapeClass | RerejsClass | RerejsDot;
 
-export type Transition = NullableTransition | NonNullableTransition;
+/**
+ * パターンに現れる文字。
+ * `null` はパターンに現れない文字を表す記号を意味する。
+ *
+ * 例えばパターンが `/ab.c/` の場合、パターンには `a, b, c` が現れるので、アルファベットは `'a', 'b', 'c', null` になる。
+ * `.` の部分の遷移は `'a', 'b', 'c', null` について追加するようにする。
+ * 否定クラスの場合も同様に、 例えば `/a[^b-d]/` の場合は、アルファベットは `'a', 'b', 'c', 'd', null` になって、
+ * `[^b-d]` の部分の遷移は `'a', null` について追加する。
+ */
+export type Char = string | null;
 
-export type NullableTransition = {
-  charSet: CharSet | null;
-  destination: State;
-};
-
-export type NonNullableTransition = {
-  charSet: CharSet;
-  destination: State;
-};
+export type NullableTransition =
+  | {
+      epsilon: false;
+      char: Char;
+      destination: State;
+    }
+  | {
+      epsilon: true;
+      destination: State;
+    };
 
 export type Message = {
   status: 'Safe' | 'Vulnerable' | 'Error';

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type Automaton =
   | NonEpsilonNFA
   | UnorderedNFA
   | DFA
-  | StronglyConnectedComponentNFA
+  | StronglyConnectedComponentGraph
   | DirectProductGraph
   | TripleDirectProductGraph;
 
@@ -39,8 +39,8 @@ export type NonEpsilonNFA = {
   transitions: TransitionMap;
 };
 
-export type StronglyConnectedComponentNFA = {
-  type: 'StronglyConnectedComponentNFA';
+export type StronglyConnectedComponentGraph = {
+  type: 'StronglyConnectedComponentGraph';
   stateList: State[];
   alphabet: Set<Char>;
   transitions: TransitionMap;

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,3 +46,13 @@ export function assignUnion<T>(set: Set<T>, subset: Set<T>): Set<T> {
   }
   return set;
 }
+
+export function subtract<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const c = new Set<T>();
+  for (const e of a) {
+    if (!b.has(e)) {
+      c.add(e);
+    }
+  }
+  return c;
+}

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -33,18 +33,33 @@ export function toDOT(
         return false;
     }
   })();
+
   const edges: Edge[] = [];
-  for (const [source, ds] of automaton.transitions) {
-    for (let i = 0; i < ds.length; i++) {
-      const d = ds[i];
+  if (automaton.type === 'EpsilonNFA') {
+    for (const [source, ds] of automaton.transitions) {
+      for (let i = 0; i < ds.length; i++) {
+        const d = ds[i];
+        edges.push({
+          source,
+          destination: d.destination,
+          priority: ordered ? i + 1 : null,
+          // TODO: その他の文字の処理
+          label: d.epsilon ? '&epsilon;' : d.char ?? '',
+        });
+      }
+    }
+  } else {
+    for (const [source, char, destination] of automaton.transitions) {
       edges.push({
         source,
-        destination: d.destination,
-        priority: ordered ? i + 1 : null,
-        label: toLabelString(d.charSet),
+        destination,
+        priority: null,
+        // TODO: その他の文字の処理
+        label: char ?? '',
       });
     }
   }
+
   let out = '';
   out += `digraph {\n`;
   if (options.horizontal) {

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -49,14 +49,19 @@ export function toDOT(
       }
     }
   } else {
-    for (const [source, char, destination] of automaton.transitions) {
-      edges.push({
-        source,
-        destination,
-        priority: null,
-        // TODO: その他の文字の処理
-        label: char ?? '',
-      });
+    for (const source of automaton.stateList) {
+      for (const char of automaton.alphabet) {
+        const destinations = automaton.transitions.get(source, char);
+        for (let i = 0; i < destinations.length; i++) {
+          edges.push({
+            source,
+            destination: destinations[i],
+            priority: ordered ? i + 1 : null,
+            // TODO: その他の文字の処理
+            label: char ?? '',
+          });
+        }
+      }
     }
   }
 

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -103,7 +103,7 @@ export function toDOT(
   for (const e of edges) {
     out += `    ${e.source} -> ${e.destination} [${
       ordered ? `taillabel = "${e.priority}", ` : ``
-    }label = ${JSON.stringify(e.label)}];\n`;
+    }label = ${JSON.stringify(e.label).replace(/\\/g, '\\\\')}];\n`;
   }
   out += `}\n`;
   return out;

--- a/src/viz.ts
+++ b/src/viz.ts
@@ -25,7 +25,7 @@ export function toDOT(
         return true;
       case 'UnorderedNFA':
         return false;
-      case 'StronglyConnectedComponentNFA':
+      case 'StronglyConnectedComponentGraph':
         return false;
       case 'DirectProductGraph':
         return false;
@@ -72,7 +72,7 @@ export function toDOT(
   }
 
   switch (automaton.type) {
-    case 'StronglyConnectedComponentNFA':
+    case 'StronglyConnectedComponentGraph':
     case 'DirectProductGraph':
     case 'TripleDirectProductGraph':
       break;


### PR DESCRIPTION
**まだ正しく動作しないためマージしないでください**

#18 で指摘いただいたように遷移関数と文字の定義を変更するものです。

手をつけられそうなところから移行していますが、変更が大きいため、ふたりにもしっかりめに確認してもらいたいと思っています。

特に SCC と 3直積は自信が無いです。各自が書いた部分の移行は結構手伝ってほしいところがあります。

主な変更点は以下です。

- 各時点でのオートマトンについて、`alphabet: Set<Char>` を持つことを強制します。`Char` は #18 で言われた通りの文字です。まだわかりませんが場合によっては `alphabet: Char[]` になるかもしれません。どちらにせよ `alphabet` の列挙によってアルゴリズムが改善できる点があれば変更お願いします。
- `NonEpsilonNFA` 移行のオートマトンについて、遷移関数を `transitions: TransitionMap` に変更します。`TransitionMap` は独自に定義したクラスで、内部的には `Map<State, Map<Char, State>>` と同じですが、各変換で初期化処理や列挙が面倒になっていることから、共通化したほうが見通しが良いと考えクラスにしました。下手にクラスを持たないほうがいいということであれば変更も考えます。

移行がつらいようであれば、時間も厳しいですし断念するかもしれません。