### PR TITLE
正しいIDA検出に修正

### DIFF
--- a/src/ida.ts
+++ b/src/ida.ts
@@ -1,5 +1,5 @@
 import { buildStronglyConnectedComponents } from './scc';
-import { TripleDirectProductGraph, Message } from './types';
+import { TripleDirectProductGraph, Message, State } from './types';
 
 export function showMessageIDA(tdps: TripleDirectProductGraph[]): Message {
   if (tdps.some((tdp) => isIDA(tdp))) {
@@ -12,10 +12,10 @@ export function showMessageIDA(tdps: TripleDirectProductGraph[]): Message {
 function isIDA(tdp: TripleDirectProductGraph): boolean {
   const sccs = buildStronglyConnectedComponents(tdp);
   return sccs.some((scc) => {
-    // 追加辺 (q1, q2, q2) => (q1, q1, q2) に対応する辺 (q1, q1, q2) => (q1, q2, q2) が強連結成分内の辺として存在するかどうかを判定
-
-    for (const [q, char, d] of tdp.extraTransitions) {
-      if (scc.transitions.get(d, char).includes(q)) {
+    // (lq, lq, rq) と (lq, rq, rq) が存在するか
+    for (const [lq, cq, rq] of scc.stateList.map((s) => s.split('_'))) {
+      const state = `${lq}_${rq}_${rq}` as State;
+      if (lq === cq && cq !== rq && scc.stateList.includes(state)) {
         return true;
       }
     }

--- a/src/ida.ts
+++ b/src/ida.ts
@@ -15,7 +15,7 @@ function isIDA(tdp: TripleDirectProductGraph): boolean {
     // (lq, lq, rq) と (lq, rq, rq) が存在するか
     for (const [lq, cq, rq] of scc.stateList.map((s) => s.split('_'))) {
       const state = `${lq}_${rq}_${rq}` as State;
-      if (lq === cq && cq !== rq && scc.stateList.includes(state)) {
+      if (lq === cq && scc.stateList.includes(state)) {
         return true;
       }
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -9,7 +9,7 @@ import { showMessageEDA } from './eda';
 import { buildTripleDirectProductGraphs } from './tripleDirectProduct';
 import { showMessageIDA } from './ida';
 
-function main() {
+function main(): void {
   const sources: [source: string, flags?: string][] = [
     [String.raw`a`],
     [String.raw`\s`],
@@ -24,10 +24,10 @@ function main() {
     [String.raw`(a+)+`],
     [String.raw`(a?)?`],
     [String.raw`(\w|\d)*`],
-    [String.raw`(.*)="(.*)"`],
     [String.raw`[a-z][0-9a-z]*`],
     [String.raw`a[a-z]`, 'i'],
-    [String.raw`a*a*`], // IDA典型例
+    [String.raw`a*a*`], // IDA1
+    [String.raw`(.*)="(.*)"`], //IDA2
   ];
 
   for (const [src, flags] of sources) {
@@ -48,6 +48,9 @@ function main() {
     console.log(`//`, src, `has EDA?: `, showMessageEDA(dps));
     console.log('//', src, `triple direct product`);
     const tdps = buildTripleDirectProductGraphs(sccs, nfa);
+    for (const tdp of tdps) {
+      console.log(toDOT(tdp));
+    }
     console.log(`//`, src, `has IDA?: `, showMessageIDA(tdps));
     console.log(`//`, src, `reversed`);
     const rnfa = reverseNFA(nfa);

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -31,7 +31,6 @@ class TripleDirectProductBuilder {
   private newStateList: State[] = [];
   private newTransitions = new TransitionMap();
   private newStateToOldStateSet: Map<State, [State, State, State]> = new Map();
-  private extraTransitions = new TransitionMap();
 
   constructor(
     private sccGraph1: StronglyConnectedComponentGraph,
@@ -40,85 +39,15 @@ class TripleDirectProductBuilder {
   ) {}
 
   build(): TripleDirectProductGraph {
-    // 強連結成分scc1, scc2間のTransitionsを取得する
-    const betweenTransitionsSCC = new TransitionMap();
-
-    for (const s1 of this.sccGraph1.stateList) {
-      for (const char of this.nfa.alphabet) {
-        for (const d of this.nfa.transitions.get(s1, char)) {
-          if (this.sccGraph2.stateList.includes(d)) {
-            betweenTransitionsSCC.add(s1, char, d);
-          }
-        }
-      }
-    }
-
-    for (const s2 of this.sccGraph2.stateList) {
-      for (const char of this.nfa.alphabet) {
-        for (const d of this.nfa.transitions.get(s2, char)) {
-          if (this.sccGraph1.stateList.includes(d)) {
-            betweenTransitionsSCC.add(s2, char, d);
-          }
-        }
-      }
-    }
-
-    // 後々のループのネストを浅くするため、2つのsccGraphの和集合を作る
-    const sumOfTwoSccStateList: Set<State> = new Set();
-
-    for (const s1 of this.sccGraph1.stateList) {
-      sumOfTwoSccStateList.add(s1);
-    }
-
-    for (const s2 of this.sccGraph2.stateList) {
-      sumOfTwoSccStateList.add(s2);
-    }
-
-    for (const ls of sumOfTwoSccStateList) {
-      for (const cs of sumOfTwoSccStateList) {
-        for (const rs of sumOfTwoSccStateList) {
-          this.createState(ls, cs, rs);
-        }
-      }
-    }
-
-    const sumOfTwoSccTransitions = new TransitionMap();
-
-    for (const [q, char, d] of this.sccGraph1.transitions) {
-      sumOfTwoSccTransitions.add(q, char, d);
-    }
-
-    for (const [q, char, d] of this.sccGraph2.transitions) {
-      sumOfTwoSccTransitions.add(q, char, d);
-    }
-
-    for (const [q, char, d] of betweenTransitionsSCC) {
-      sumOfTwoSccTransitions.add(q, char, d);
-    }
-
-    const alphabet = new Set([
-      ...this.sccGraph1.alphabet,
-      ...this.sccGraph2.alphabet,
-      ...this.nfa.alphabet,
-    ]);
-
-    for (const lq of sumOfTwoSccStateList) {
-      for (const cq of sumOfTwoSccStateList) {
-        for (const rq of sumOfTwoSccStateList) {
-          for (const char of alphabet) {
-            for (const ld of sumOfTwoSccTransitions.get(lq, char)) {
-              for (const cd of sumOfTwoSccTransitions.get(cq, char)) {
-                for (const rd of sumOfTwoSccTransitions.get(rq, char)) {
-                  let source = this.getState(lq, cq, rq);
-                  if (source === null) {
-                    source = this.createState(lq, cq, rq);
-                  }
-
-                  let dest = this.getState(ld, cd, rd);
-                  if (dest === null) {
-                    dest = this.createState(ld, cd, rd);
-                  }
-
+    for (const lq of this.sccGraph1.stateList) {
+      for (const cq of this.nfa.stateList) {
+        for (const rq of this.sccGraph2.stateList) {
+          for (const char of this.nfa.alphabet) {
+            for (const ld of this.sccGraph1.transitions.get(lq, char)) {
+              for (const cd of this.nfa.transitions.get(cq, char)) {
+                for (const rd of this.sccGraph2.transitions.get(rq, char)) {
+                  const source = this.createState(lq, cq, rq);
+                  const dest = this.createState(ld, cd, rd);
                   this.newTransitions.add(source, char, dest);
                 }
               }
@@ -129,36 +58,26 @@ class TripleDirectProductBuilder {
     }
 
     // IDA判定のために、強連結成分間の戻る辺を追加
-    for (const [s, char, d] of betweenTransitionsSCC) {
-      let exs = this.getState(s, d, d);
-      if (exs === null) {
-        exs = this.createState(s, d, d);
+    for (const lq of this.sccGraph1.stateList) {
+      for (const rq of this.sccGraph2.stateList) {
+        for (const a of this.nfa.alphabet) {
+          const source = this.createState(lq, rq, rq);
+          const dest = this.createState(lq, lq, rq);
+          this.newTransitions.add(source, a, dest);
+        }
       }
-
-      let exd = this.getState(s, s, d);
-      if (exd === null) {
-        exd = this.createState(s, s, d);
-      }
-
-      this.newTransitions.add(exs, char, exd);
-
-      this.extraTransitions.add(exs, char, exd);
     }
 
     return {
       type: 'TripleDirectProductGraph',
       stateList: this.newStateList,
-      alphabet,
+      alphabet: this.nfa.alphabet,
       transitions: this.newTransitions,
-      extraTransitions: this.extraTransitions,
     };
   }
 
-  getState(
-    leftState: State,
-    centerState: State,
-    rightState: State,
-  ): State | null {
+  // 直積は前の状態をスペース区切りに
+  createState(leftState: State, centerState: State, rightState: State): State {
     for (const [ns, os] of this.newStateToOldStateSet) {
       if (
         os[0] === leftState &&
@@ -168,15 +87,9 @@ class TripleDirectProductBuilder {
         return ns;
       }
     }
-    return null;
-  }
 
-  // 直積は前の状態をスペース区切りに
-  createState(leftState: State, centerState: State, rightState: State): State {
     const state = `${leftState}_${centerState}_${rightState}` as State;
-
     this.newStateList.push(state);
-
     this.newStateToOldStateSet.set(state, [leftState, centerState, rightState]);
     return state;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,6 @@ export type TripleDirectProductGraph = {
   stateList: State[];
   alphabet: Set<Char>;
   transitions: TransitionMap;
-  extraTransitions: TransitionMap;
 };
 
 export type UnorderedNFA = {


### PR DESCRIPTION
```
// (\w|\d)* has IDA?:  { status: 'Safe', message: "Don't have IDA." }
// [a-z][0-9a-z]* has IDA?:  { status: 'Safe', message: "Don't have IDA." }
// a[a-z] has IDA?:  { status: 'Safe', message: "Don't have IDA." }
// a*a* has IDA?:  { status: 'Vulnerable', message: 'Detected IDA.' }
// (.*)="(.*)" has IDA?:  { status: 'Vulnerable', message: 'Detected IDA.' }
```
３つの状態の直積を作るところが間違っていました。