### PR TITLE
状態のタプルを移行 (#22)

### DIFF
--- a/src/dfa.ts
+++ b/src/dfa.ts
@@ -23,46 +23,46 @@ export function reverseNFA(nfa: NonEpsilonNFA): UnorderedNFA {
 export function determinize(nfa: UnorderedNFA): DFA {
   const queue: [State, Set<State>][] = [];
 
-  const alphabet = nfa.alphabet;
-  const stateList: State[] = [];
-  const transitions = new TransitionMap();
-  const initialState = State.fromSet(nfa.initialStateSet);
-  const acceptingStateSet = new Set<State>();
+  const newStateList: State[] = [];
+  const newTransitions = new TransitionMap();
+  const newInitialState = State.fromSet(nfa.initialStateSet);
+  const newAcceptingStateSet = new Set<State>();
   const table = new Map<State, Set<State>>();
 
-  stateList.push(initialState);
-  table.set(initialState, nfa.initialStateSet);
-  queue.push([initialState, nfa.initialStateSet]);
+  newStateList.push(newInitialState);
+  table.set(newInitialState, nfa.initialStateSet);
+  queue.push([newInitialState, nfa.initialStateSet]);
 
   while (queue.length !== 0) {
     const [q0, qs0] = queue.shift()!;
 
     if (intersect(qs0, nfa.acceptingStateSet).size !== 0) {
-      acceptingStateSet.add(q0);
+      newAcceptingStateSet.add(q0);
     }
 
-    for (const char of alphabet) {
+    for (const char of nfa.alphabet) {
       const qs1 = new Set(
         Array.from(qs0).flatMap((q) => nfa.transitions.get(q, char)),
       );
 
       const q1 = State.fromSet(qs1);
-      if (!stateList.includes(q1)) {
-        stateList.push(q1);
+      if (!newStateList.includes(q1)) {
+        newStateList.push(q1);
         table.set(q1, qs1);
         queue.push([q1, qs1]);
       }
 
-      transitions.add(q0, char, q1);
+      newTransitions.add(q0, char, q1);
     }
   }
+
   return {
     type: 'DFA',
-    stateList,
-    alphabet,
-    initialState,
-    acceptingStateSet,
-    transitions,
+    stateList: newStateList,
+    alphabet: nfa.alphabet,
+    initialState: newInitialState,
+    acceptingStateSet: newAcceptingStateSet,
+    transitions: newTransitions,
     table,
   };
 }

--- a/src/directProduct.ts
+++ b/src/directProduct.ts
@@ -14,25 +14,19 @@ export function buildDirectProductGraph(
   return new DirectProductBuilder(sccGraph).build();
 }
 
-export function getLeftState(state: State): State {
-  return state.split('_')[0] as State;
-}
-
-export function getRightState(state: State): State {
-  return state.split('_')[1] as State;
-}
-
 class DirectProductBuilder {
   private newStateList: State[] = [];
   private newTransitions = new TransitionMap();
-  private newStateToOldStateSet: Map<State, [State, State]> = new Map();
+  private table: Map<State, [State, State]> = new Map();
 
   constructor(private sccGraph: StronglyConnectedComponentGraph) {}
 
   build(): DirectProductGraph {
     for (const ls of this.sccGraph.stateList) {
       for (const rs of this.sccGraph.stateList) {
-        this.createState(ls, rs);
+        const newState = State.fromPair([ls, rs]);
+        this.newStateList.push(newState);
+        this.table.set(newState, [ls, rs]);
       }
     }
 
@@ -41,15 +35,9 @@ class DirectProductBuilder {
         for (const char of this.sccGraph.alphabet) {
           for (const ld of this.sccGraph.transitions.get(lq, char)) {
             for (const rd of this.sccGraph.transitions.get(rq, char)) {
-              let source = this.getState(lq, rq);
-              if (source === null) {
-                source = this.createState(lq, rq);
-              }
+              const source = State.fromPair([lq, rq]);
 
-              let dest = this.getState(ld, rd);
-              if (dest === null) {
-                dest = this.createState(ld, rd);
-              }
+              const dest = State.fromPair([ld, rd]);
 
               // 2重辺も許容する
               this.newTransitions.add(source, char, dest);
@@ -64,25 +52,7 @@ class DirectProductBuilder {
       stateList: this.newStateList,
       alphabet: this.sccGraph.alphabet,
       transitions: this.newTransitions,
+      table: this.table,
     };
-  }
-
-  getState(leftState: State, rightState: State): State | null {
-    for (const [ns, os] of this.newStateToOldStateSet) {
-      if (os[0] === leftState && os[1] === rightState) {
-        return ns;
-      }
-    }
-    return null;
-  }
-
-  // 直積は前の状態をスペース区切りに
-  createState(leftState: State, rightState: State): State {
-    const state = `${leftState}_${rightState}` as State;
-
-    this.newStateList.push(state);
-
-    this.newStateToOldStateSet.set(state, [leftState, rightState]);
-    return state;
   }
 }

--- a/src/eda.ts
+++ b/src/eda.ts
@@ -1,4 +1,3 @@
-import { getLeftState, getRightState } from './directProduct';
 import { buildStronglyConnectedComponents } from './scc';
 import { DirectProductGraph, Message } from './types';
 
@@ -30,9 +29,10 @@ function isEDA(dp: DirectProductGraph): boolean {
       }
     }
 
-    const lrSame = scc.stateList.filter(
-      (state) => getLeftState(state) === getRightState(state),
-    );
+    const lrSame = scc.stateList.filter((state) => {
+      const [lq, rq] = dp.table.get(state)!;
+      return lq === rq;
+    });
     // (n, n), (m, k) (m !== k)が存在(すべて同じじゃないが全て異なるわけではない)
     return lrSame.length < scc.stateList.length && lrSame.length > 0;
   });

--- a/src/ida.ts
+++ b/src/ida.ts
@@ -14,8 +14,8 @@ function isIDA(tdp: TripleDirectProductGraph): boolean {
   const sccs = buildStronglyConnectedComponents(tdp);
   return sccs.some((scc) => {
     // (lq, lq, rq) と (lq, rq, rq) が存在するか
-    for (const [lq, cq, rq] of scc.stateList.map((s) => s.split('_'))) {
-      const state = `${lq}_${rq}_${rq}` as State;
+    for (const [lq, cq, rq] of scc.stateList.map((s) => tdp.table.get(s)!)) {
+      const state = State.fromTriple([lq, rq, rq]);
       if (lq === cq && scc.stateList.includes(state)) {
         return true;
       }

--- a/src/pruning.ts
+++ b/src/pruning.ts
@@ -69,6 +69,7 @@ export function prune(nfa: NonEpsilonNFA, dfa: DFA): PrunedNFA {
     initialStateSet: newInitialStateSet,
     acceptingStateSet: newAcceptingStateSet,
     transitions: newTransitions,
+    table: table,
   });
 }
 
@@ -80,6 +81,7 @@ function removeUnreachableState(pnfa: PrunedNFA): PrunedNFA {
   const newAcceptingStateSet: Set<State> = new Set();
   const newAlphabet: Set<Char> = new Set();
   const newTransitions = new TransitionMap();
+  const newTable: Map<State, [State, State]> = new Map();
 
   const queue: State[] = Array.from(pnfa.initialStateSet);
   // 到達可能なStateを入れたSet
@@ -102,6 +104,11 @@ function removeUnreachableState(pnfa: PrunedNFA): PrunedNFA {
     }
   }
 
+  // newTableの更新
+  for (const state of newStatesSet) {
+    newTable.set(state, pnfa.table.get(state)!);
+  }
+
   for (const [q0, char, q1] of pnfa.transitions) {
     if (newStatesSet.has(q0) && newStatesSet.has(q1)) {
       newTransitions.add(q0, char, q1);
@@ -116,6 +123,7 @@ function removeUnreachableState(pnfa: PrunedNFA): PrunedNFA {
     initialStateSet: pnfa.initialStateSet,
     acceptingStateSet: newAcceptingStateSet,
     transitions: newTransitions,
+    table: newTable,
   };
 }
 

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -77,8 +77,11 @@ class TripleDirectProductBuilder {
     };
   }
 
-  // 直積は前の状態をスペース区切りに
-  createState(leftState: State, centerState: State, rightState: State): State {
+  private createState(
+    leftState: State,
+    centerState: State,
+    rightState: State,
+  ): State {
     const newState = State.fromTriple([leftState, centerState, rightState]);
     if (!this.newStateList.includes(newState)) {
       this.newStateList.push(newState);

--- a/src/tripleDirectProduct.ts
+++ b/src/tripleDirectProduct.ts
@@ -30,7 +30,7 @@ export function buildTripleDirectProductGraph(
 class TripleDirectProductBuilder {
   private newStateList: State[] = [];
   private newTransitions = new TransitionMap();
-  private newStateToOldStateSet: Map<State, [State, State, State]> = new Map();
+  private table: Map<State, [State, State, State]> = new Map();
 
   constructor(
     private sccGraph1: StronglyConnectedComponentGraph,
@@ -73,24 +73,17 @@ class TripleDirectProductBuilder {
       stateList: this.newStateList,
       alphabet: this.nfa.alphabet,
       transitions: this.newTransitions,
+      table: this.table,
     };
   }
 
   // 直積は前の状態をスペース区切りに
   createState(leftState: State, centerState: State, rightState: State): State {
-    for (const [ns, os] of this.newStateToOldStateSet) {
-      if (
-        os[0] === leftState &&
-        os[1] === centerState &&
-        os[2] === rightState
-      ) {
-        return ns;
-      }
+    const newState = State.fromTriple([leftState, centerState, rightState]);
+    if (!this.newStateList.includes(newState)) {
+      this.newStateList.push(newState);
+      this.table.set(newState, [leftState, centerState, rightState]);
     }
-
-    const state = `${leftState}_${centerState}_${rightState}` as State;
-    this.newStateList.push(state);
-    this.newStateToOldStateSet.set(state, [leftState, centerState, rightState]);
-    return state;
+    return newState;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export type PrunedNFA = {
   initialStateSet: Set<State>;
   acceptingStateSet: Set<State>;
   transitions: TransitionMap;
+  table: Map<State, [State, State]>;
 };
 
 export type StronglyConnectedComponentGraph = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,8 +78,8 @@ export type StronglyConnectedComponentGraph = {
 
 export type DirectProductGraph = {
   type: 'DirectProductGraph';
-  alphabet: Set<Char>;
   stateList: State[];
+  alphabet: Set<Char>;
   transitions: TransitionMap;
   table: Map<State, [State, State]>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export type DirectProductGraph = {
   alphabet: Set<Char>;
   stateList: State[];
   transitions: TransitionMap;
+  table: Map<State, [State, State]>;
 };
 
 export type TripleDirectProductGraph = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export type TripleDirectProductGraph = {
   stateList: State[];
   alphabet: Set<Char>;
   transitions: TransitionMap;
+  table: Map<State, [State, State, State]>;
 };
 
 export type Atom = RerejsChar | RerejsEscapeClass | RerejsClass | RerejsDot;


### PR DESCRIPTION
#22 の移行（State を `q0_q1` ではなく `(q0, q1)` にする）を DirectProductGraph と TripleDirectProduct にも施したものです。

#26 をやる上で必要になったので出しました。

（試しに提案されたブランチ名ルールを取り入れてみたけど、プッシュ先は master です）