### PR TITLE
二重Stateを作成しないBFSに修正+test.jsの微修正

### DIFF
--- a/src/pruning.ts
+++ b/src/pruning.ts
@@ -75,7 +75,6 @@ export function prune(nfa: NonEpsilonNFA, dfa: DFA): PrunedNFA {
 /**
  * 初期状態から幅優先探索をして到達できる点のみのNFAを作成
  * 到達不能なStateを除去し、そのState内における遷移とアルファベットのみを追加
- * TODO: Viz謝表示時を修正(本来二重でない辺を二重に描いてしまう)
  */
 function removeUnreachableState(pnfa: PrunedNFA): PrunedNFA {
   const newAcceptingStateSet: Set<State> = new Set();

--- a/src/test.ts
+++ b/src/test.ts
@@ -35,7 +35,7 @@ function main(): void {
 
   for (const [src, flags] of sources) {
     console.log(`//`, src, flags);
-    const pat = new Parser(src).parse();
+    const pat = new Parser(src, flags).parse();
     const enfa = buildEpsilonNFA(pat);
     console.log(toDOT(enfa));
     console.log(`//`, src, `eliminated`);
@@ -47,10 +47,9 @@ function main(): void {
     console.log(`//`, src, `determinized`);
     const dfa = determinize(rnfa);
     console.log(toDOT(dfa));
-    console.log(`//`, src, `cut leaf`);
+    console.log(`//`, src, `pruned`);
     const lcnfa = prune(nfa, dfa);
     console.log(toDOT(lcnfa));
-    console.log(`//`, src, `strongly connected components`);
     const sccs = buildStronglyConnectedComponents(lcnfa);
     const dps = buildDirectProductGraphs(sccs);
     console.log(`//`, src, `has EDA?: `, showMessageEDA(dps));


### PR DESCRIPTION
- BFSでそのStateが到達可能と判定できた時点でnewStatesSetに入れるように
- 到達可能という意味なので、到達可能なStateの集合からdestへの辺が存在してdestがまだ訪れていない場合、queueとnewStateSetにdestを入れてしまう
- queueにあるStateを入れた時点でnewStatesSetにもそのStateを入れる。queueに入った時点で到達可能と判定できる