### PR TITLE
pages(ブラウザからの視覚化)が動いてない問題の修正

### DIFF
--- a/pages/package.json
+++ b/pages/package.json
@@ -16,5 +16,8 @@
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.4"
-  }
+  },
+  "browserslist": [
+    "since 2017-06"
+  ]
 }


### PR DESCRIPTION
## 解決する Issue(Bug)

これは本筋とは外れますが、ブラウザからの視覚化機能を開いてみた所エラーになっていたので、修正に取り組んでみました。(小さいエラーなので、issueを建てるまでもないかなと思いました)

## 修正内容

https://blog.makotoishida.com/2020/07/parcelasyncawaitregeneratorruntime-is.html
を参考にして、pages/package.jsonに
```
"browserslist": [
    "since 2017-06"
]
```
を追加して見た所、ローカル環境では動きました。
