### PR TITLE
エラーハンドリングを実装

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,33 +11,28 @@ import { showMessageIDA } from './ida';
 import { Message } from './types';
 
 export function detectReDoS(src: string, flags?: string): Message {
-  try {
-    const pat = new Parser(src, flags).parse();
-    const enfa = buildEpsilonNFA(pat);
-    const nfa = eliminateEpsilonTransitions(enfa);
-    const rnfa = reverseNFA(nfa);
-    const dfa = determinize(rnfa);
-    const pnfa = prune(nfa, dfa);
-    const sccs = buildStronglyConnectedComponents(pnfa);
-    const dps = buildDirectProductGraphs(sccs);
-    const messageEDA = showMessageEDA(pnfa, dfa, dps);
-    if (messageEDA.status === 'Vulnerable') {
-      return messageEDA;
-    }
-    const tdps = buildTripleDirectProductGraphs(sccs, pnfa);
-    const messageIDA = showMessageIDA(pnfa, dfa, tdps);
-    if (messageIDA.status === 'Vulnerable') {
-      return messageIDA;
-    }
-    return {
-      status: 'Safe',
-      message: "Don't have EDA nor IDA",
-    } as Message;
-  } catch (e) {
-    if (e instanceof Error) {
-      return { status: 'Error', message: e.message };
-    } else {
-      return { status: 'Error', message: 'Undefined Error.' };
-    }
+  const pat = new Parser(src, flags).parse();
+  const enfa = buildEpsilonNFA(pat);
+  if (enfa.type === 'Error') {
+    return { status: 'Error', message: enfa.error.message };
   }
+  const nfa = eliminateEpsilonTransitions(enfa);
+  const rnfa = reverseNFA(nfa);
+  const dfa = determinize(rnfa);
+  const pnfa = prune(nfa, dfa);
+  const sccs = buildStronglyConnectedComponents(pnfa);
+  const dps = buildDirectProductGraphs(sccs);
+  const messageEDA = showMessageEDA(pnfa, dfa, dps);
+  if (messageEDA.status === 'Vulnerable') {
+    return messageEDA;
+  }
+  const tdps = buildTripleDirectProductGraphs(sccs, pnfa);
+  const messageIDA = showMessageIDA(pnfa, dfa, tdps);
+  if (messageIDA.status === 'Vulnerable') {
+    return messageIDA;
+  }
+  return {
+    status: 'Safe',
+    message: "Don't have EDA nor IDA",
+  } as Message;
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -45,6 +45,7 @@ function main(): void {
     [String.raw`(.*|(a|a)*)`], // 枝切り1
     [String.raw`(a|a)*?.*`], // 枝切り2
     [String.raw`^a|b$|aa`],
+    [String.raw`^ab^c`], // エラー回復用
     [String.raw`^$`], // 空文字に一致
   ];
 
@@ -52,6 +53,11 @@ function main(): void {
     console.log(`//`, src, flags);
     const pat = new Parser(src, flags).parse();
     const enfa = buildEpsilonNFA(pat);
+    if (enfa.type === 'Error') {
+      // detectReDosを用いる場合、Objectが返されるがここではmessageのみ
+      console.error('Error Message:', enfa.error.message);
+      continue;
+    }
     console.log(toDOT(enfa));
     console.log(`//`, src, `eliminated`);
     const nfa = eliminateEpsilonTransitions(enfa);

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,3 +130,10 @@ export type Message =
       status: 'Error';
       message: string;
     };
+
+export type ErrorType = { type: 'Error'; error: Error };
+
+export type BuildChildResult = { type: 'BuildChildResult' } & Pick<
+  EpsilonNFA,
+  'initialState' | 'acceptingState'
+>;


### PR DESCRIPTION
# 解決する Issue

close #45  

# 改善内容

- buildChildを実行時にエラー発生した場合にエラーハンドリングしそれ相当のメッセージを表示(以前はハンドリングしておらず自動で落ちていた)